### PR TITLE
feat: parallel sub-agent spawning (call_subagents)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -41,7 +41,15 @@
       "Read(//tmp/**)",
       "Bash(\"C:\\\\Users\\\\bmisa\\\\src\\\\agent_framework\\\\tests\\\\test_framework_runtime.py\":*)",
       "Skill(commit-commands:commit)",
-      "Bash(gh pr:*)"
+      "Bash(gh pr:*)",
+      "WebFetch(domain:docs.claude.com)",
+      "WebFetch(domain:www.anthropic.com)",
+      "WebFetch(domain:openai.github.io)",
+      "WebFetch(domain:google.github.io)",
+      "WebFetch(domain:claude.com)",
+      "WebFetch(domain:adk.dev)",
+      "WebFetch(domain:gist.github.com)",
+      "WebFetch(domain:trio.readthedocs.io)"
     ]
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,7 +90,8 @@ Each agent runs a loop: call model → parse `AgentDecision` → act → repeat.
 Decision kinds (closed set; any other top-level `kind` after alias normalization is invalid):
 - `final_message` — agent is done, returns `AgentResult`
 - `call_tool` — invoke a registered tool, add result to context
-- `call_subagent` — delegate to a child agent via `host.call_subagent`
+- `call_subagent` — delegate to a single child agent via `host.call_subagent`
+- `call_subagents` — dispatch a batch of child agents (parallel or sequential) via `host.call_subagent_batch`; each entry specifies `subagent_id`, `parameters`, `output_key`
 - `callback` — escalate to caller (human or parent agent)
 - `invoke_skill` — invoke a named skill from the catalog
 
@@ -140,6 +141,11 @@ COMMANDS_DIRECTORIES=path/a,path/b     # multiple commands directories (comma-se
 # MCP
 MCP_CONFIG_PATH=path/to/mcp.json       # explicit .mcp.json path (default: auto-discover)
 MCP_ENABLED=true                        # set false to disable MCP entirely
+
+# Parallel sub-agents
+SUBAGENT_BATCH_TIMEOUT_SECONDS=300     # wall-clock deadline per call_subagents batch (default: 300)
+SUBAGENT_MAX_PARALLELISM=8             # max entries per call_subagents decision (default: 8)
+SUBAGENT_BATCH_MAX_CALLBACK_ROUNDS=5   # max callback-resolve-resume rounds per batch (default: 5)
 ```
 
 ### Extensibility

--- a/src/agent_framework/agents/__init__.py
+++ b/src/agent_framework/agents/__init__.py
@@ -3,7 +3,7 @@
 from .agent import Agent
 from .helpers import AgentMarkdownError
 from .agent_behavior import AgentBehavior
-from .agent_decision import AgentDecision
+from .agent_decision import AgentDecision, SubagentCallSpec
 from .agent_end_event import AgentEndEvent
 from .agent_end_hook_decision import AgentEndHookDecision
 from .agent_hook_decision import AgentHookDecision
@@ -31,6 +31,7 @@ __all__ = [
     "AgentMarkdownError",
     "AgentBehavior",
     "AgentDecision",
+    "SubagentCallSpec",
     "AgentEndEvent",
     "AgentEndHookDecision",
     "AgentHookDecision",

--- a/src/agent_framework/agents/agent.py
+++ b/src/agent_framework/agents/agent.py
@@ -275,6 +275,8 @@ class Agent:
         rendered_prompt_override: str | None = None,
         conversation_messages: tuple[dict[str, str], ...] | None = None,
         prompt_fragments: tuple[str, ...] | None = None,
+        run_id: str | None = None,
+        in_parallel_batch: bool = False,
     ) -> AgentResult:
         """Execute the agent loop for one invocation.
 
@@ -293,6 +295,8 @@ class Agent:
         """
         run = self._create_run(
             parameters or {},
+            run_id=run_id,
+            in_parallel_batch=in_parallel_batch,
             rendered_prompt_override=rendered_prompt_override,
             conversation_messages=conversation_messages,
             prompt_fragments=prompt_fragments,
@@ -496,6 +500,7 @@ class Agent:
             "final_message": self.handle_final_message,
             "callback": self.handle_callback,
             "call_subagent": self.handle_subagent_call,
+            "call_subagents": self.handle_subagent_calls,
             "call_tool": self.handle_tool_call,
             "invoke_skill": self.handle_skill_invocation,
         }
@@ -550,6 +555,22 @@ class Agent:
         caller_id: str | None,
     ) -> AgentResult | None:
         """Handle all callback-style requests through one unified transport."""
+        if run.in_parallel_batch:
+            # Parallel children cannot block on user/caller input — save conversation
+            # state so the batch orchestrator can resume after resolving the callback.
+            save_fn = getattr(host, "save_checkpoint", None)
+            if callable(save_fn):
+                save_fn(run.run_id, list(run.conversation_messages))
+            return AgentResult(
+                status="blocked",
+                message=json.dumps({
+                    "intent": decision.callback_intent or "information_request",
+                    "prompt": decision.message,
+                    "parameters": decision.parameters,
+                }),
+                decision=decision,
+                prompt=run.rendered_prompt,
+            )
         intent = decision.callback_intent or "information_request"
         parameter_name = str(decision.parameters.get("parameter_name", "")).strip()
         spec = self._parameter_spec_by_name().get(parameter_name) if parameter_name else None
@@ -791,6 +812,92 @@ class Agent:
         )
         return None
 
+    def handle_subagent_calls(
+        self,
+        *,
+        host: "AgentHostProtocol",
+        run: AgentRun,
+        decision: AgentDecision,
+        caller_id: str | None,
+    ) -> AgentResult | None:
+        """Handle a call_subagents batch decision (parallel or sequential)."""
+        from agent_framework.agent_event_publisher import agent_events
+
+        # Validate every call entry against the allowed child agent list.
+        for spec in decision.subagent_calls:
+            if spec.subagent_id not in self.allowed_child_agents:
+                error_text = (
+                    f"{self.agent_id} is not allowed to call subagent {spec.subagent_id!r} "
+                    f"(output_key={spec.output_key!r}). "
+                    f"Legal subagent ids: {sorted(self.allowed_child_agents)}."
+                )
+                run.prompt_fragments.append(f"<subagent_error>{error_text}</subagent_error>")
+                run.transcript_entries.append(f"<subagent_error>{error_text}</subagent_error>")
+                run.conversation_messages.append({"role": "user", "content": error_text})
+                _emit_context_updated(self, host, run, run.conversation_messages[-1], "subagent_validation_error")
+                return None
+
+        agent_events.audit_named_event(
+            run_id=run.run_id,
+            agent_id=self.agent_id,
+            event={
+                "type": "subagent_batch_call",
+                "mode": decision.batch_mode,
+                "count": len(decision.subagent_calls),
+                "calls": [{"subagent_id": s.subagent_id, "output_key": s.output_key} for s in decision.subagent_calls],
+            },
+        )
+
+        call_batch_fn = getattr(host, "call_subagent_batch", None)
+        if not callable(call_batch_fn):
+            error_text = "Host does not support call_subagent_batch; upgrade AgentHost."
+            run.prompt_fragments.append(f"<subagent_error>{error_text}</subagent_error>")
+            run.conversation_messages.append({"role": "user", "content": error_text})
+            _emit_context_updated(self, host, run, run.conversation_messages[-1], "subagent_error")
+            return None
+
+        try:
+            results = call_batch_fn(
+                caller=self,
+                specs=decision.subagent_calls,
+                mode=decision.batch_mode,
+                timeout_seconds=decision.batch_timeout_seconds,
+                parent_run_id=run.run_id,
+            )
+        except Exception as exc:
+            error_text = f"call_subagent_batch failed: {type(exc).__name__}: {exc}"
+            run.prompt_fragments.append(f"<subagent_error>{error_text}</subagent_error>")
+            run.conversation_messages.append({"role": "user", "content": error_text})
+            _emit_context_updated(self, host, run, run.conversation_messages[-1], "subagent_error")
+            return None
+
+        self._emit_subagent_batch_results(host, run, results)
+        return None
+
+    def _emit_subagent_batch_results(
+        self,
+        host: "AgentHostProtocol",
+        run: AgentRun,
+        results: list[Any],
+    ) -> None:
+        """Build the aggregated <subagent_results> fragment and add it to the run."""
+        lines = ["<subagent_results>"]
+        for r in results:
+            attrs = f'key="{r.output_key}" agent_id="{r.subagent_id}" status="{r.status}"'
+            if r.status == "blocked" and r.callback_intent:
+                attrs += f' intent="{r.callback_intent}"'
+            if r.message:
+                lines.append(f"  <subagent_result {attrs}>{r.message}</subagent_result>")
+            else:
+                lines.append(f"  <subagent_result {attrs}/>")
+        lines.append("</subagent_results>")
+        fragment = "\n".join(lines)
+
+        run.prompt_fragments.append(fragment)
+        run.transcript_entries.append(fragment)
+        run.conversation_messages.append({"role": "user", "content": fragment})
+        _emit_context_updated(self, host, run, run.conversation_messages[-1], "subagent_batch_results")
+
     def handle_skill_invocation(
         self,
         *,
@@ -1016,6 +1123,8 @@ class Agent:
         self,
         parameters: dict[str, Any],
         *,
+        run_id: str | None = None,
+        in_parallel_batch: bool = False,
         rendered_prompt_override: str | None = None,
         conversation_messages: tuple[dict[str, str], ...] | None = None,
         prompt_fragments: tuple[str, ...] | None = None,
@@ -1023,9 +1132,8 @@ class Agent:
         """Create runtime state for a new invocation."""
         seed_parameters = dict(parameters)
         return AgentRun(
-            run_id=str(uuid4()),
-            # Persist the base prompt per run so execution is traceable even if
-            # the agent definition changes later.
+            run_id=run_id or str(uuid4()),
+            in_parallel_batch=in_parallel_batch,
             rendered_prompt=rendered_prompt_override or self._render_seed_prompt(seed_parameters),
             seed_parameters=seed_parameters,
             parameter_values={},

--- a/src/agent_framework/agents/agent_decision.py
+++ b/src/agent_framework/agents/agent_decision.py
@@ -16,10 +16,20 @@ _ALLOWED_DECISION_KINDS: Final[frozenset[str]] = frozenset(
         "final_message",
         "call_tool",
         "call_subagent",
+        "call_subagents",
         "callback",
         "invoke_skill",
     }
 )
+
+
+@dataclass(frozen=True, slots=True)
+class SubagentCallSpec:
+    """One entry in a call_subagents batch decision."""
+
+    subagent_id: str
+    parameters: dict[str, Any] = field(default_factory=dict)
+    output_key: str = ""  # filled to "call_<i>" by parser when absent
 
 
 def _optional_text(value: object) -> str | None:
@@ -41,6 +51,10 @@ class AgentDecision:
     tool_name: str | None = None
     callback_intent: str | None = None
     skill_name: str | None = None
+    # call_subagents fields (populated only when kind == "call_subagents")
+    batch_mode: str | None = None
+    batch_timeout_seconds: float | None = None
+    subagent_calls: tuple[SubagentCallSpec, ...] = field(default_factory=tuple)
 
     @classmethod
     def from_model_response(cls, response: ModelResponse) -> "AgentDecision":
@@ -101,6 +115,66 @@ class AgentDecision:
                 "use exactly one target per decision."
             )
 
+        # Parse call_subagents-specific fields.
+        batch_mode: str | None = None
+        batch_timeout_seconds: float | None = None
+        subagent_calls: tuple[SubagentCallSpec, ...] = ()
+
+        if normalized_kind == "call_subagents":
+            raw_mode = payload.get("mode")
+            if raw_mode not in ("parallel", "sequential"):
+                raise ValueError(
+                    "Invalid model decision JSON: call_subagents requires 'mode' set to "
+                    f"'parallel' or 'sequential'; got {raw_mode!r}."
+                )
+            batch_mode = str(raw_mode)
+
+            raw_timeout = payload.get("timeout_seconds")
+            if raw_timeout is not None:
+                try:
+                    t = float(raw_timeout)
+                except (TypeError, ValueError):
+                    t = -1.0
+                if t <= 0:
+                    raise ValueError(
+                        "Invalid model decision JSON: call_subagents 'timeout_seconds' "
+                        f"must be a positive number; got {raw_timeout!r}."
+                    )
+                batch_timeout_seconds = t
+
+            raw_calls = payload.get("calls")
+            if not isinstance(raw_calls, list) or len(raw_calls) == 0:
+                raise ValueError(
+                    "Invalid model decision JSON: call_subagents 'calls' must be a "
+                    "non-empty list."
+                )
+            specs: list[SubagentCallSpec] = []
+            for i, entry in enumerate(raw_calls):
+                if not isinstance(entry, dict):
+                    raise ValueError(
+                        f"Invalid model decision JSON: call_subagents 'calls[{i}]' "
+                        "must be a JSON object."
+                    )
+                entry_subagent_id = _optional_text(entry.get("subagent_id"))
+                if not entry_subagent_id:
+                    raise ValueError(
+                        f"Invalid model decision JSON: call_subagents 'calls[{i}]' "
+                        "is missing 'subagent_id'."
+                    )
+                entry_tool_name = _optional_text(entry.get("tool_name"))
+                if entry_tool_name is not None:
+                    raise ValueError(
+                        f"Invalid model decision JSON: call_subagents 'calls[{i}]' "
+                        "must not set 'tool_name'; use 'subagent_id' only."
+                    )
+                entry_output_key = _optional_text(entry.get("output_key")) or f"call_{i}"
+                specs.append(SubagentCallSpec(
+                    subagent_id=entry_subagent_id,
+                    parameters=dict(entry.get("parameters", {}) or {}),
+                    output_key=entry_output_key,
+                ))
+            subagent_calls = tuple(specs)
+
         return cls(
             kind=normalized_kind,
             message=str(payload.get("message", "")).strip(),
@@ -109,7 +183,10 @@ class AgentDecision:
             tool_name=tool_name,
             callback_intent=callback_intent,
             skill_name=_optional_text(payload.get("skill_name")),
+            batch_mode=batch_mode,
+            batch_timeout_seconds=batch_timeout_seconds,
+            subagent_calls=subagent_calls,
         )
 
 
-__all__ = ["AgentDecision"]
+__all__ = ["AgentDecision", "SubagentCallSpec"]

--- a/src/agent_framework/agents/agent_host_protocol.py
+++ b/src/agent_framework/agents/agent_host_protocol.py
@@ -7,6 +7,7 @@ from typing import Any, Protocol, TYPE_CHECKING
 
 from agent_framework.model import ModelDriver
 
+from .agent_decision import SubagentCallSpec
 from .agent_result import AgentResult
 from .call_context import CallContext
 from .model_end_event import ModelEndEvent
@@ -35,7 +36,27 @@ class AgentHostProtocol(Protocol):
         callee_id: str,
         parameters: dict[str, Any],
         parent_run_id: str | None = None,
+        run_id: str | None = None,
+        in_parallel_batch: bool = False,
+        conversation_messages: "tuple[dict, ...] | None" = None,
     ) -> AgentResult:
+        raise NotImplementedError
+
+    def call_subagent_batch(
+        self,
+        *,
+        caller: "Agent",
+        specs: "tuple[SubagentCallSpec, ...]",
+        mode: str,
+        timeout_seconds: "float | None",
+        parent_run_id: "str | None" = None,
+    ) -> list:
+        raise NotImplementedError
+
+    def save_checkpoint(self, run_id: str, messages: list) -> None:
+        raise NotImplementedError
+
+    def load_checkpoint(self, run_id: str) -> "list | None":
         raise NotImplementedError
 
     def execute_tool(self, tool_name: str, parameters: dict[str, Any]) -> str:

--- a/src/agent_framework/agents/agent_run.py
+++ b/src/agent_framework/agents/agent_run.py
@@ -24,5 +24,6 @@ class AgentRun:
     conversation_messages: list[dict[str, str]] = field(default_factory=list)
     contexts: list[CallContext] = field(default_factory=list)
     history: list[str] = field(default_factory=list)
+    in_parallel_batch: bool = False
 
 __all__ = ["AgentRun"]

--- a/src/agent_framework/agents/system.decision.md
+++ b/src/agent_framework/agents/system.decision.md
@@ -10,8 +10,23 @@ Rules:
 Decision kinds:
 - `final_message` — agent is done, returns result to caller
 - `call_tool` — invoke a registered tool by name
-- `call_subagent` — delegate to a child agent
+- `call_subagent` — delegate to a single child agent
+- `call_subagents` — dispatch multiple child agents in one turn; requires `mode` (`"parallel"` or `"sequential"`) and `calls` (non-empty list of `{"subagent_id": "...", "parameters": {...}, "output_key": "..."}`)
 - `callback` — escalate to caller; set `intent` to one of: `information_request`, `proposal_review`, `execution_recovery`, `delegation_return`, `policy_or_approval`, `guardrail_trip`
 - `invoke_skill` — invoke a named skill; set `skill_name` to a valid skill name from `<available_skills>`
 
 Do not set both `subagent_id` and `tool_name` in the same decision.
+
+For `call_subagents`:
+- `mode: "parallel"` — all children run concurrently; children must not emit callbacks (use `mode: "sequential"` or gather information first)
+- `mode: "sequential"` — children run one at a time in order
+- `timeout_seconds` — optional wall-clock deadline (default: 300)
+- Each `calls` entry: `subagent_id` required; `parameters` defaults to `{}`; `output_key` defaults to `call_<index>`
+
+Example `call_subagents`:
+```json
+{"kind": "call_subagents", "mode": "parallel", "calls": [
+  {"subagent_id": "researcher", "parameters": {"topic": "X"}, "output_key": "research"},
+  {"subagent_id": "critic", "parameters": {"topic": "X"}, "output_key": "critique"}
+]}
+```

--- a/src/agent_framework/agents/system.json_object.md
+++ b/src/agent_framework/agents/system.json_object.md
@@ -41,7 +41,7 @@ When the current agent system prompt is asking for a runtime action, return a si
 
 ```json
 {
-  "kind": "final_message | callback | call_subagent | call_tool",
+  "kind": "final_message | callback | call_subagent | call_subagents | call_tool",
   "intent": "information_request | proposal_review | execution_recovery | delegation_return | policy_or_approval | guardrail_trip",
   "message": "string",
   "subagent_id": "string",
@@ -56,6 +56,7 @@ When the current agent system prompt is asking for a runtime action, return a si
     - "final_message": the agent finished producing results and returns to the caller
     - "callback": the agent needs some information or decision from the caller agent (if caller agent is host, it will prompt for the information / decision for the user). "intent", "message" and "parameters" are populated
     - "call_subagent": the agent calls a subagent to respond to the prompt. "message" contains the user prompt, "subagent_id" is populated. "parameters" are populated matching the subagent specification
+    - "call_subagents": dispatch multiple subagents; set "mode" to "parallel" or "sequential" and "calls" to a list of {"subagent_id", "parameters", "output_key"} objects
     - "call_tool": the agent calls a tool. "tool_name" is populated. "parameters" are populated matching the tool specification
     - "invoke_skill": invoke a named skill; set `skill_name` to a valid skill name from `<available_skills>`
 - `message`: MUST contain all user-facing information (no other information will be visible to the end user).

--- a/src/agent_framework/agents/system.md
+++ b/src/agent_framework/agents/system.md
@@ -21,6 +21,15 @@ You are a standalone agent. You use your knowledge and the available tools and a
 3. Never put a subagent id in tool_name.
 4. Use the subagent definition (subagent_name.md file), retrieve contents between <user_prompt>  tags, populate the template for the user prompt.
 
+### Parallel fan-out with `call_subagents`
+
+Use `call_subagents` (plural) when multiple independent agents can work concurrently:
+- `(a → b → c)` — sequential: one `call_subagents` with `mode: "sequential"` and three entries
+- `(a ‖ b) → c` — mixed: one parallel `call_subagents` for a and b, then a second turn with `call_subagent` for c
+- `(a ‖ b ‖ c)` — pure parallel: one `call_subagents` with `mode: "parallel"` and three entries
+
+In parallel mode, children cannot emit callbacks. If a child needs information from the caller, use `mode: "sequential"` or gather the information yourself before the fan-out.
+
 ## Information Retrieval
 
 If any information is missing, use the following workflow to fill it in:

--- a/src/agent_framework/host.py
+++ b/src/agent_framework/host.py
@@ -3,9 +3,12 @@
 from __future__ import annotations
 
 import asyncio
+import contextvars
 import logging
 import os
-from concurrent.futures import Future, ThreadPoolExecutor
+import threading
+import time
+from concurrent.futures import Future, ThreadPoolExecutor, wait as _futures_wait
 from datetime import datetime
 from dataclasses import dataclass, field, fields, replace
 from pathlib import Path
@@ -13,6 +16,7 @@ from typing import Any, Awaitable, Callable, Sequence
 from uuid import uuid4
 
 from agent_framework.agent import Agent, AgentResult, CallContext, ModelEndEvent, ModelStartEvent, SequentialHook
+from agent_framework.agents.agent_decision import SubagentCallSpec
 from agent_framework.agent_registry import AgentRegistry
 from agent_framework.agent_event_publisher import agent_events
 from agent_framework.audit_trace import AuditTraceSubscriber, InMemoryAuditTracer
@@ -44,6 +48,19 @@ from agent_framework.tracing_bridge import active_tracer_scope
 from agent_framework.user_communication import NullUserCommunication, UserCommunication
 
 _LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class SubagentBatchItemResult:
+    """Result for one entry in a call_subagents batch."""
+
+    output_key: str
+    subagent_id: str
+    run_id: str
+    status: str  # "completed" | "failed" | "timed_out" | "blocked"
+    message: str = ""
+    callback_intent: str | None = None
+    callback_prompt: str | None = None
 
 
 def _agent_host_receive_log_enabled_from_env() -> bool:
@@ -98,6 +115,13 @@ class AgentHost:
     _registries_discovered: bool = field(default=False, repr=False)
     _host_receive_log_subscriber: TraceSubscriber | None = field(default=None, repr=False)
     _host_receive_log_path: Path | None = field(default=None, repr=False)
+    # Hierarchical run ID — stable for the lifetime of this host instance.
+    session_id: str = field(default_factory=lambda: str(uuid4())[:12], repr=False)
+    _prompt_counter: int = field(default=0, repr=False)
+    _prompt_counter_lock: threading.Lock = field(default_factory=threading.Lock, repr=False)
+    # Checkpoint storage for blocked parallel children (run_id → (messages, timestamp)).
+    _checkpoints: dict[str, tuple[list, float]] = field(default_factory=dict, repr=False)
+    _checkpoint_lock: threading.Lock = field(default_factory=threading.Lock, repr=False)
 
     @property
     def audit_tracer(self) -> InMemoryAuditTracer | None:
@@ -791,6 +815,12 @@ class AgentHost:
         rt_behavior.attach(wired)
         return wired
 
+    def _next_prompt_counter(self) -> int:
+        """Thread-safely increment and return the prompt counter."""
+        with self._prompt_counter_lock:
+            self._prompt_counter += 1
+            return self._prompt_counter
+
     def run_agent(
         self,
         agent_id: str,
@@ -801,6 +831,8 @@ class AgentHost:
     ) -> AgentResult:
         """Run a specific agent id as a top-level invocation."""
         agent = self._agent_with_runtime_tracing(self.get_agent(agent_id))
+        prompt_num = self._next_prompt_counter()
+        root_run_id = f"{self.session_id}.p{prompt_num}.{agent_id}"
         with active_tracer_scope(self.runtime_tracer, self.trace_context_overlay):
             return agent.run(
                 host=self,
@@ -809,6 +841,7 @@ class AgentHost:
                 rendered_prompt_override=initial_instruction or "",
                 conversation_messages=conversation_messages,
                 prompt_fragments=prompt_fragments,
+                run_id=root_run_id,
             )
 
     def run_console(self) -> AgentResult:
@@ -834,16 +867,23 @@ class AgentHost:
         callee_id: str,
         parameters: dict[str, Any],
         parent_run_id: str | None = None,
+        run_id: str | None = None,
+        in_parallel_batch: bool = False,
+        conversation_messages: tuple[dict[str, str], ...] | None = None,
     ) -> AgentResult:
         """Synchronously invoke a child agent from a caller agent."""
         base_dir = caller.source_path.parent if caller.source_path is not None else None
         callee = self._agent_with_runtime_tracing(self.get_agent(callee_id, base_dir=base_dir))
+        child_run_id = run_id or (f"{parent_run_id}.{callee_id}" if parent_run_id else None)
         with active_tracer_scope(self.runtime_tracer, self.trace_context_overlay):
             return callee.run(
                 host=self,
                 parameters=parameters,
                 caller_id=caller.agent_id,
                 parent_run_id=parent_run_id,
+                run_id=child_run_id,
+                in_parallel_batch=in_parallel_batch,
+                conversation_messages=conversation_messages,
             )
 
     def call_subagent_async(
@@ -853,14 +893,260 @@ class AgentHost:
         callee_id: str,
         parameters: dict[str, Any],
         parent_run_id: str | None = None,
+        run_id: str | None = None,
+        in_parallel_batch: bool = False,
+        conversation_messages: tuple[dict[str, str], ...] | None = None,
     ) -> Future[AgentResult]:
-        """Invoke a child agent on the thread pool for parallel execution."""
+        """Invoke a child agent on the thread pool for parallel execution.
+
+        Captures the current contextvars context so tracer scope and other
+        context variables propagate correctly into the worker thread.
+        """
+        ctx = contextvars.copy_context()
         return self._executor.submit(
+            ctx.run,
             self.call_subagent,
             caller=caller,
             callee_id=callee_id,
             parameters=parameters,
             parent_run_id=parent_run_id,
+            run_id=run_id,
+            in_parallel_batch=in_parallel_batch,
+            conversation_messages=conversation_messages,
+        )
+
+    # ------------------------------------------------------------------
+    # Checkpoint storage for parallel-batch callback resume
+    # ------------------------------------------------------------------
+
+    def save_checkpoint(self, run_id: str, messages: list[dict]) -> None:
+        """Persist conversation state for a blocked parallel child."""
+        with self._checkpoint_lock:
+            self._checkpoints[run_id] = (list(messages), time.monotonic())
+
+    def load_checkpoint(self, run_id: str) -> list[dict] | None:
+        """Return saved conversation messages for a run_id, or None."""
+        with self._checkpoint_lock:
+            entry = self._checkpoints.get(run_id)
+        return list(entry[0]) if entry is not None else None
+
+    def delete_checkpoint(self, run_id: str) -> None:
+        """Remove a checkpoint after the child has completed or failed."""
+        with self._checkpoint_lock:
+            self._checkpoints.pop(run_id, None)
+
+    def cleanup_checkpoints(self, ttl_seconds: float = 3600.0) -> int:
+        """Remove checkpoints older than ttl_seconds.  Returns count removed."""
+        cutoff = time.monotonic() - ttl_seconds
+        with self._checkpoint_lock:
+            expired = [k for k, (_, ts) in self._checkpoints.items() if ts < cutoff]
+            for k in expired:
+                del self._checkpoints[k]
+        return len(expired)
+
+    # ------------------------------------------------------------------
+    # Parallel / sequential batch orchestration
+    # ------------------------------------------------------------------
+
+    def call_subagent_batch(
+        self,
+        *,
+        caller: Agent,
+        specs: tuple[SubagentCallSpec, ...],
+        mode: str,
+        timeout_seconds: float | None,
+        parent_run_id: str | None = None,
+    ) -> list[SubagentBatchItemResult]:
+        """Orchestrate a call_subagents batch with callback-resume loop."""
+        max_parallelism = int(os.environ.get("SUBAGENT_MAX_PARALLELISM", "8"))
+        if len(specs) > max_parallelism:
+            raise ValueError(
+                f"call_subagents batch size {len(specs)} exceeds SUBAGENT_MAX_PARALLELISM={max_parallelism}."
+            )
+        timeout = timeout_seconds if timeout_seconds is not None else float(
+            os.environ.get("SUBAGENT_BATCH_TIMEOUT_SECONDS", "300")
+        )
+        max_rounds = int(os.environ.get("SUBAGENT_BATCH_MAX_CALLBACK_ROUNDS", "5"))
+
+        # pending_specs is a list of (SubagentCallSpec, child_run_id, conversation_messages)
+        pending: list[tuple[SubagentCallSpec, str, tuple[dict, ...] | None]] = [
+            (s, f"{parent_run_id}.{s.output_key}" if parent_run_id else s.output_key, None)
+            for s in specs
+        ]
+        final_results: list[SubagentBatchItemResult] = []
+
+        for round_num in range(max_rounds + 1):
+            if not pending:
+                break
+
+            if mode == "parallel":
+                round_results = self._run_parallel_round(caller, pending, timeout, parent_run_id)
+            else:
+                round_results = self._run_sequential_round(caller, pending, timeout, parent_run_id)
+
+            blocked = [r for r in round_results if r.status == "blocked"]
+            final_results.extend(r for r in round_results if r.status != "blocked")
+
+            if not blocked:
+                break
+
+            if round_num == max_rounds:
+                for r in blocked:
+                    self.delete_checkpoint(r.run_id)
+                    final_results.append(replace(r, status="failed", message="max callback rounds exceeded"))
+                break
+
+            # Resolve callbacks and build resume specs.
+            pending = []
+            for br in blocked:
+                saved = self.load_checkpoint(br.run_id)
+                if saved is None:
+                    final_results.append(replace(br, status="failed", message="checkpoint not found after block"))
+                    continue
+                try:
+                    callee = self.get_agent(br.subagent_id)
+                    answer = self.resolve_callback(
+                        caller_id=caller.agent_id,
+                        callee=callee,
+                        prompt=br.callback_prompt or "",
+                    )
+                except Exception as exc:
+                    self.delete_checkpoint(br.run_id)
+                    final_results.append(replace(br, status="failed", message=f"callback resolution error: {exc}"))
+                    continue
+                resumed_messages = tuple(saved + [{"role": "user", "content": answer}])
+                # Find original spec to get parameters.
+                orig_spec = next((s for s in specs if s.output_key == br.output_key), None)
+                if orig_spec is None:
+                    orig_spec = SubagentCallSpec(subagent_id=br.subagent_id, output_key=br.output_key)
+                pending.append((orig_spec, br.run_id, resumed_messages))
+
+        # Clean up any remaining checkpoints for non-blocked results.
+        for r in final_results:
+            if r.status != "blocked":
+                self.delete_checkpoint(r.run_id)
+
+        return final_results
+
+    def _run_parallel_round(
+        self,
+        caller: Agent,
+        pending: list[tuple[SubagentCallSpec, str, tuple[dict, ...] | None]],
+        timeout: float,
+        parent_run_id: str | None,
+    ) -> list[SubagentBatchItemResult]:
+        future_to_key: dict[Future[AgentResult], tuple[SubagentCallSpec, str]] = {}
+        for spec, child_run_id, convo in pending:
+            # Each future needs its own context copy — a single Context object
+            # cannot be entered concurrently by multiple threads.
+            ctx = contextvars.copy_context()
+            fut = self._executor.submit(
+                ctx.run,
+                self.call_subagent,
+                caller=caller,
+                callee_id=spec.subagent_id,
+                parameters=spec.parameters,
+                parent_run_id=parent_run_id,
+                run_id=child_run_id,
+                in_parallel_batch=True,
+                conversation_messages=convo,
+            )
+            future_to_key[fut] = (spec, child_run_id)
+
+        done, not_done = _futures_wait(list(future_to_key), timeout=timeout)
+        results: list[SubagentBatchItemResult] = []
+
+        for fut, (spec, child_run_id) in future_to_key.items():
+            if fut in not_done:
+                results.append(SubagentBatchItemResult(
+                    output_key=spec.output_key,
+                    subagent_id=spec.subagent_id,
+                    run_id=child_run_id,
+                    status="timed_out",
+                ))
+                continue
+            try:
+                agent_result = fut.result()
+            except Exception as exc:
+                results.append(SubagentBatchItemResult(
+                    output_key=spec.output_key,
+                    subagent_id=spec.subagent_id,
+                    run_id=child_run_id,
+                    status="failed",
+                    message=f"{type(exc).__name__}: {exc}",
+                ))
+                continue
+            results.append(self._agent_result_to_batch_item(spec, child_run_id, agent_result))
+
+        return results
+
+    def _run_sequential_round(
+        self,
+        caller: Agent,
+        pending: list[tuple[SubagentCallSpec, str, tuple[dict, ...] | None]],
+        timeout: float,
+        parent_run_id: str | None,
+    ) -> list[SubagentBatchItemResult]:
+        deadline = time.monotonic() + timeout
+        results: list[SubagentBatchItemResult] = []
+        for spec, child_run_id, convo in pending:
+            if time.monotonic() >= deadline:
+                results.append(SubagentBatchItemResult(
+                    output_key=spec.output_key,
+                    subagent_id=spec.subagent_id,
+                    run_id=child_run_id,
+                    status="timed_out",
+                ))
+                continue
+            try:
+                agent_result = self.call_subagent(
+                    caller=caller,
+                    callee_id=spec.subagent_id,
+                    parameters=spec.parameters,
+                    parent_run_id=parent_run_id,
+                    run_id=child_run_id,
+                    in_parallel_batch=False,
+                    conversation_messages=convo,
+                )
+            except Exception as exc:
+                results.append(SubagentBatchItemResult(
+                    output_key=spec.output_key,
+                    subagent_id=spec.subagent_id,
+                    run_id=child_run_id,
+                    status="failed",
+                    message=f"{type(exc).__name__}: {exc}",
+                ))
+                continue
+            results.append(self._agent_result_to_batch_item(spec, child_run_id, agent_result))
+        return results
+
+    @staticmethod
+    def _agent_result_to_batch_item(
+        spec: SubagentCallSpec,
+        child_run_id: str,
+        result: AgentResult,
+    ) -> SubagentBatchItemResult:
+        if result.status == "blocked":
+            try:
+                import json as _json
+                payload = _json.loads(result.message) if result.message else {}
+            except Exception:
+                payload = {}
+            return SubagentBatchItemResult(
+                output_key=spec.output_key,
+                subagent_id=spec.subagent_id,
+                run_id=child_run_id,
+                status="blocked",
+                message=result.message,
+                callback_intent=payload.get("intent"),
+                callback_prompt=payload.get("prompt", ""),
+            )
+        return SubagentBatchItemResult(
+            output_key=spec.output_key,
+            subagent_id=spec.subagent_id,
+            run_id=child_run_id,
+            status=result.status,
+            message=result.message,
         )
 
     def execute_tool(self, tool_name: str, parameters: dict[str, Any]) -> str:

--- a/src/agent_framework/tracing_subscribers/jsonl_subscriber.py
+++ b/src/agent_framework/tracing_subscribers/jsonl_subscriber.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import threading
 from dataclasses import asdict
 from pathlib import Path
 
@@ -13,10 +14,12 @@ class JsonlTraceSubscriber:
     def __init__(self, output_path: Path) -> None:
         self.output_path = Path(output_path)
         self.output_path.parent.mkdir(parents=True, exist_ok=True)
+        self._lock = threading.Lock()
 
     def consume(self, event: TraceEvent) -> None:
-        with self.output_path.open("a", encoding="utf-8") as handle:
-            handle.write(json.dumps(asdict(event), ensure_ascii=False) + "\n")
+        with self._lock:
+            with self.output_path.open("a", encoding="utf-8") as handle:
+                handle.write(json.dumps(asdict(event), ensure_ascii=False) + "\n")
 
 
 __all__ = ["JsonlTraceSubscriber"]

--- a/tests/test_parallel_subagents.py
+++ b/tests/test_parallel_subagents.py
@@ -1,0 +1,628 @@
+"""Tests for call_subagents parallel/sequential batch execution."""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+import pytest
+
+from agent_framework.agents.agent_decision import AgentDecision, SubagentCallSpec
+from agent_framework.agents.agent_result import AgentResult
+from agent_framework.agents.agent_run import AgentRun
+from agent_framework.host import AgentHost, SubagentBatchItemResult
+from agent_framework.config import HostConfig
+
+
+# ---------------------------------------------------------------------------
+# Helpers shared across tests
+# ---------------------------------------------------------------------------
+
+class FakeModelDriver:
+    def __init__(self, payloads):
+        self._payloads = list(payloads)
+        self.on_request_trace = None
+        self.on_response_trace = None
+
+    def set_trace_callbacks(self, *, on_request=None, on_response=None):
+        self.on_request_trace = on_request
+        self.on_response_trace = on_response
+
+    def decide(self, *, agent_id, provider_name, model_names, temperature, context):
+        from agent_framework.model import ModelResponse
+        payload = self._payloads.pop(0)
+        return ModelResponse(payload=payload, raw_text=json.dumps(payload))
+
+
+def make_host(tmp_path: Path, *, agents_dir: Path | None = None) -> AgentHost:
+    env_path = tmp_path / ".env"
+    agents = agents_dir or (tmp_path / "agents")
+    agents.mkdir(exist_ok=True)
+    env_path.write_text(
+        "\n".join([
+            "OPENAI_API_KEY=test-key",
+            "DEFAULT_PROVIDER=openai",
+            "DEFAULT_MODEL=gpt-4o-mini",
+            f"AGENT_DIRECTORY={agents}",
+            "TOOLS_DIRECTORY=tools",
+            "WORLD_DIRECTORY=world",
+            "ROOT_AGENT=root",
+        ]),
+        encoding="utf-8",
+    )
+    from agent_framework.config import load_host_config
+    config = load_host_config(env_path)
+    return AgentHost.create(model_driver=FakeModelDriver([]), config=config, builtin_tools=False)
+
+
+def write_agent(agents_dir: Path, agent_id: str, subagents: list[str] | None = None) -> Path:
+    agents_dir.mkdir(parents=True, exist_ok=True)
+    subagents_yaml = ""
+    if subagents:
+        lines = "\n".join(f"  - {s}" for s in subagents)
+        subagents_yaml = f"subagents:\n{lines}\n"
+    path = agents_dir / f"{agent_id}.md"
+    path.write_text(
+        f"---\nid: {agent_id}\nrole: {agent_id}\n{subagents_yaml}---\nYou are {agent_id}.\n---\nDo the task.\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+# ---------------------------------------------------------------------------
+# 1. Decision parsing — valid
+# ---------------------------------------------------------------------------
+
+def test_decision_parsing_valid():
+    payload = {
+        "kind": "call_subagents",
+        "mode": "parallel",
+        "calls": [
+            {"subagent_id": "researcher", "parameters": {"topic": "X"}, "output_key": "research"},
+            {"subagent_id": "critic", "output_key": "critique"},
+        ],
+    }
+    from agent_framework.model import ModelResponse
+    d = AgentDecision.from_model_response(ModelResponse(payload=payload, raw_text=""))
+    assert d.kind == "call_subagents"
+    assert d.batch_mode == "parallel"
+    assert len(d.subagent_calls) == 2
+    assert d.subagent_calls[0].subagent_id == "researcher"
+    assert d.subagent_calls[0].output_key == "research"
+    assert d.subagent_calls[1].subagent_id == "critic"
+    assert d.subagent_calls[1].output_key == "critique"
+
+
+# ---------------------------------------------------------------------------
+# 2. Decision parsing — rejects missing mode
+# ---------------------------------------------------------------------------
+
+def test_decision_parsing_rejects_missing_mode():
+    payload = {"kind": "call_subagents", "calls": [{"subagent_id": "x"}]}
+    from agent_framework.model import ModelResponse
+    with pytest.raises(ValueError, match="mode"):
+        AgentDecision.from_model_response(ModelResponse(payload=payload, raw_text=""))
+
+
+# ---------------------------------------------------------------------------
+# 3. Decision parsing — rejects empty calls
+# ---------------------------------------------------------------------------
+
+def test_decision_parsing_rejects_empty_calls():
+    payload = {"kind": "call_subagents", "mode": "parallel", "calls": []}
+    from agent_framework.model import ModelResponse
+    with pytest.raises(ValueError, match="calls"):
+        AgentDecision.from_model_response(ModelResponse(payload=payload, raw_text=""))
+
+
+# ---------------------------------------------------------------------------
+# 4. Decision parsing — rejects non-positive timeout
+# ---------------------------------------------------------------------------
+
+def test_decision_parsing_rejects_nonpositive_timeout():
+    payload = {
+        "kind": "call_subagents",
+        "mode": "parallel",
+        "timeout_seconds": -1,
+        "calls": [{"subagent_id": "x"}],
+    }
+    from agent_framework.model import ModelResponse
+    with pytest.raises(ValueError, match="timeout_seconds"):
+        AgentDecision.from_model_response(ModelResponse(payload=payload, raw_text=""))
+
+
+# ---------------------------------------------------------------------------
+# 5. Default output_key assigned by parser
+# ---------------------------------------------------------------------------
+
+def test_decision_parsing_default_output_keys():
+    payload = {
+        "kind": "call_subagents",
+        "mode": "sequential",
+        "calls": [{"subagent_id": "a"}, {"subagent_id": "b"}],
+    }
+    from agent_framework.model import ModelResponse
+    d = AgentDecision.from_model_response(ModelResponse(payload=payload, raw_text=""))
+    assert d.subagent_calls[0].output_key == "call_0"
+    assert d.subagent_calls[1].output_key == "call_1"
+
+
+# ---------------------------------------------------------------------------
+# 6. Context isolation — child starts with empty conversation
+# ---------------------------------------------------------------------------
+
+def test_context_isolation(tmp_path: Path):
+    agents_dir = tmp_path / "agents"
+    write_agent(agents_dir, "root", subagents=["child"])
+    write_agent(agents_dir, "child")
+
+    child_convo_at_start: list = []
+
+    from agent_framework.agents.agent import Agent
+    original_run = Agent.run
+
+    def patched_run(self, *, host, parameters=None, caller_id=None, **kwargs):
+        if self.agent_id == "child":
+            run = self._create_run(parameters or {}, **{
+                k: v for k, v in kwargs.items()
+                if k in ("run_id", "in_parallel_batch", "rendered_prompt_override",
+                         "conversation_messages", "prompt_fragments")
+            })
+            child_convo_at_start.extend(run.conversation_messages)
+            return AgentResult(status="completed", message="done", prompt="")
+        return original_run(self, host=host, parameters=parameters, caller_id=caller_id, **kwargs)
+
+    host = make_host(tmp_path, agents_dir=agents_dir)
+    driver = FakeModelDriver([{"kind": "call_subagent", "subagent_id": "child", "parameters": {}}])
+    host.model_driver = driver
+
+    from agent_framework.agents.agent import Agent
+    import unittest.mock as mock
+    with mock.patch.object(Agent, "run", patched_run):
+        # Prime root with a conversation message
+        root = host.get_agent("root")
+        root_run = root._create_run({})
+        root_run.conversation_messages.append({"role": "user", "content": "existing parent message"})
+        # Call child directly
+        host.call_subagent(caller=root, callee_id="child", parameters={}, parent_run_id="parent-run")
+
+    # Child should start with empty conversation
+    assert child_convo_at_start == []
+
+
+# ---------------------------------------------------------------------------
+# 7. Sequential execution order
+# ---------------------------------------------------------------------------
+
+def test_sequential_order(tmp_path: Path):
+    agents_dir = tmp_path / "agents"
+    write_agent(agents_dir, "root", subagents=["a", "b", "c"])
+    for name in ["a", "b", "c"]:
+        write_agent(agents_dir, name)
+
+    invocation_order: list[str] = []
+    invocation_lock = threading.Lock()
+
+    host = make_host(tmp_path, agents_dir=agents_dir)
+
+    def fake_call_subagent(*, caller, callee_id, parameters, parent_run_id=None,
+                           run_id=None, in_parallel_batch=False, conversation_messages=None):
+        with invocation_lock:
+            invocation_order.append(callee_id)
+        return AgentResult(status="completed", message=f"{callee_id} done", prompt="")
+
+    specs = (
+        SubagentCallSpec(subagent_id="a", output_key="ka"),
+        SubagentCallSpec(subagent_id="b", output_key="kb"),
+        SubagentCallSpec(subagent_id="c", output_key="kc"),
+    )
+
+    import unittest.mock as mock
+    with mock.patch.object(AgentHost, "call_subagent", side_effect=fake_call_subagent):
+        root = host.get_agent("root")
+        results = host.call_subagent_batch(
+            caller=root, specs=specs, mode="sequential", timeout_seconds=30
+        )
+
+    assert invocation_order == ["a", "b", "c"]
+    assert all(r.status == "completed" for r in results)
+
+
+# ---------------------------------------------------------------------------
+# 8. Parallel execution is actually concurrent
+# ---------------------------------------------------------------------------
+
+def test_parallel_concurrent(tmp_path: Path):
+    agents_dir = tmp_path / "agents"
+    write_agent(agents_dir, "root", subagents=["slow_a", "slow_b"])
+    write_agent(agents_dir, "slow_a")
+    write_agent(agents_dir, "slow_b")
+
+    host = make_host(tmp_path, agents_dir=agents_dir)
+
+    def fake_call_subagent(*, caller, callee_id, parameters, parent_run_id=None,
+                           run_id=None, in_parallel_batch=False, conversation_messages=None):
+        time.sleep(0.3)
+        return AgentResult(status="completed", message=f"{callee_id} done", prompt="")
+
+    specs = (
+        SubagentCallSpec(subagent_id="slow_a", output_key="a"),
+        SubagentCallSpec(subagent_id="slow_b", output_key="b"),
+    )
+
+    import unittest.mock as mock
+    with mock.patch.object(AgentHost, "call_subagent", side_effect=fake_call_subagent):
+        root = host.get_agent("root")
+        start = time.monotonic()
+        results = host.call_subagent_batch(
+            caller=root, specs=specs, mode="parallel", timeout_seconds=10
+        )
+        elapsed = time.monotonic() - start
+
+    assert elapsed < 0.55, f"Expected parallel execution < 0.55s, got {elapsed:.2f}s"
+    assert all(r.status == "completed" for r in results)
+
+
+# ---------------------------------------------------------------------------
+# 9. Parallel timeout abandons slow children
+# ---------------------------------------------------------------------------
+
+def test_parallel_timeout(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("SUBAGENT_BATCH_TIMEOUT_SECONDS", "0.2")
+    agents_dir = tmp_path / "agents"
+    write_agent(agents_dir, "root", subagents=["fast", "slow"])
+    write_agent(agents_dir, "fast")
+    write_agent(agents_dir, "slow")
+
+    host = make_host(tmp_path, agents_dir=agents_dir)
+
+    def fake_call_subagent(*, caller, callee_id, parameters, parent_run_id=None,
+                           run_id=None, in_parallel_batch=False, conversation_messages=None):
+        if callee_id == "slow":
+            time.sleep(5)
+        return AgentResult(status="completed", message=f"{callee_id} done", prompt="")
+
+    specs = (
+        SubagentCallSpec(subagent_id="fast", output_key="fast_key"),
+        SubagentCallSpec(subagent_id="slow", output_key="slow_key"),
+    )
+
+    import unittest.mock as mock
+    with mock.patch.object(AgentHost, "call_subagent", side_effect=fake_call_subagent):
+        root = host.get_agent("root")
+        results = host.call_subagent_batch(
+            caller=root, specs=specs, mode="parallel", timeout_seconds=0.2
+        )
+
+    by_key = {r.output_key: r for r in results}
+    assert by_key["fast_key"].status == "completed"
+    assert by_key["slow_key"].status == "timed_out"
+
+
+# ---------------------------------------------------------------------------
+# 10. Aggregated fragment content
+# ---------------------------------------------------------------------------
+
+def test_aggregated_fragment(tmp_path: Path):
+    agents_dir = tmp_path / "agents"
+    write_agent(agents_dir, "root", subagents=["a", "b"])
+    write_agent(agents_dir, "a")
+    write_agent(agents_dir, "b")
+
+    host = make_host(tmp_path, agents_dir=agents_dir)
+
+    specs = (
+        SubagentCallSpec(subagent_id="a", output_key="alpha"),
+        SubagentCallSpec(subagent_id="b", output_key="beta"),
+    )
+
+    def fake_call_subagent(*, caller, callee_id, parameters, parent_run_id=None,
+                           run_id=None, in_parallel_batch=False, conversation_messages=None):
+        return AgentResult(status="completed", message=f"{callee_id}-result", prompt="")
+
+    import unittest.mock as mock
+    with mock.patch.object(AgentHost, "call_subagent", side_effect=fake_call_subagent):
+        root = host.get_agent("root")
+        root_run = root._create_run({})
+        results = host.call_subagent_batch(
+            caller=root, specs=specs, mode="sequential", timeout_seconds=30
+        )
+        root._emit_subagent_batch_results(host, root_run, results)
+
+    fragment = root_run.prompt_fragments[-1]
+    assert "<subagent_results>" in fragment
+    assert 'key="alpha"' in fragment
+    assert 'key="beta"' in fragment
+    assert "a-result" in fragment
+    assert "b-result" in fragment
+
+    convo_msg = root_run.conversation_messages[-1]
+    assert convo_msg["role"] == "user"
+    assert "<subagent_results>" in convo_msg["content"]
+
+
+# ---------------------------------------------------------------------------
+# 11. Parallelism cap rejected loudly
+# ---------------------------------------------------------------------------
+
+def test_parallelism_cap(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("SUBAGENT_MAX_PARALLELISM", "2")
+    agents_dir = tmp_path / "agents"
+    write_agent(agents_dir, "root", subagents=["a", "b", "c"])
+    for name in ["a", "b", "c"]:
+        write_agent(agents_dir, name)
+
+    host = make_host(tmp_path, agents_dir=agents_dir)
+    root = host.get_agent("root")
+    specs = (
+        SubagentCallSpec(subagent_id="a", output_key="a"),
+        SubagentCallSpec(subagent_id="b", output_key="b"),
+        SubagentCallSpec(subagent_id="c", output_key="c"),
+    )
+    with pytest.raises(ValueError, match="SUBAGENT_MAX_PARALLELISM"):
+        host.call_subagent_batch(caller=root, specs=specs, mode="parallel", timeout_seconds=30)
+
+
+# ---------------------------------------------------------------------------
+# 12. Child failure does not affect siblings
+# ---------------------------------------------------------------------------
+
+def test_child_failure_isolation(tmp_path: Path):
+    agents_dir = tmp_path / "agents"
+    write_agent(agents_dir, "root", subagents=["good", "bad"])
+    write_agent(agents_dir, "good")
+    write_agent(agents_dir, "bad")
+
+    host = make_host(tmp_path, agents_dir=agents_dir)
+
+    def fake_call_subagent(*, caller, callee_id, parameters, parent_run_id=None,
+                           run_id=None, in_parallel_batch=False, conversation_messages=None):
+        if callee_id == "bad":
+            raise RuntimeError("child exploded")
+        return AgentResult(status="completed", message="good done", prompt="")
+
+    specs = (
+        SubagentCallSpec(subagent_id="good", output_key="good_key"),
+        SubagentCallSpec(subagent_id="bad", output_key="bad_key"),
+    )
+
+    import unittest.mock as mock
+    with mock.patch.object(AgentHost, "call_subagent", side_effect=fake_call_subagent):
+        root = host.get_agent("root")
+        results = host.call_subagent_batch(
+            caller=root, specs=specs, mode="parallel", timeout_seconds=10
+        )
+
+    by_key = {r.output_key: r for r in results}
+    assert by_key["good_key"].status == "completed"
+    assert by_key["bad_key"].status == "failed"
+    assert "child exploded" in by_key["bad_key"].message
+
+
+# ---------------------------------------------------------------------------
+# 13. Parallel callback saves checkpoint and returns blocked
+# ---------------------------------------------------------------------------
+
+def test_parallel_callback_saves_checkpoint_and_blocks(tmp_path: Path):
+    agents_dir = tmp_path / "agents"
+    write_agent(agents_dir, "root", subagents=["asker"])
+    write_agent(agents_dir, "asker")
+
+    host = make_host(tmp_path, agents_dir=agents_dir)
+    driver = FakeModelDriver([
+        {"kind": "callback", "intent": "information_request", "message": "what is X?"},
+    ])
+    host.model_driver = driver
+
+    asker = host.get_agent("asker")
+    child_run_id = "test-session.p1.root.ask_key"
+    result = asker.run(
+        host=host,
+        parameters={},
+        caller_id="root",
+        run_id=child_run_id,
+        in_parallel_batch=True,
+    )
+
+    assert result.status == "blocked"
+    payload = json.loads(result.message)
+    assert payload["intent"] == "information_request"
+    assert payload["prompt"] == "what is X?"
+
+    # Checkpoint must have been saved.
+    saved = host.load_checkpoint(child_run_id)
+    assert saved is not None
+
+
+# ---------------------------------------------------------------------------
+# 14. Callback resume restores conversation history
+# ---------------------------------------------------------------------------
+
+def test_callback_resume_restores_history(tmp_path: Path):
+    agents_dir = tmp_path / "agents"
+    write_agent(agents_dir, "root", subagents=["asker"])
+    write_agent(agents_dir, "asker")
+
+    host = make_host(tmp_path, agents_dir=agents_dir)
+
+    # Round 1: child emits callback → blocked.
+    # Round 2: child receives answer → completes.
+    seen_conversation: list[list] = []
+
+    from agent_framework.agents.agent import Agent
+    original_run = Agent.run
+    call_count = [0]
+
+    def patched_run(self, *, host, parameters=None, caller_id=None, conversation_messages=None,
+                    run_id=None, in_parallel_batch=False, **kwargs):
+        call_count[0] += 1
+        if call_count[0] == 1:
+            # First call: simulate a callback block with checkpoint saved.
+            run = self._create_run(
+                parameters or {},
+                run_id=run_id,
+                in_parallel_batch=in_parallel_batch,
+                conversation_messages=conversation_messages,
+            )
+            run.conversation_messages.append({"role": "assistant", "content": "thinking..."})
+            save_fn = getattr(host, "save_checkpoint", None)
+            if callable(save_fn):
+                save_fn(run.run_id, list(run.conversation_messages))
+            return AgentResult(
+                status="blocked",
+                message=json.dumps({"intent": "information_request", "prompt": "need X", "parameters": {}}),
+                prompt="",
+            )
+        else:
+            # Second call: record the conversation passed in.
+            seen_conversation.append(list(conversation_messages or []))
+            return AgentResult(status="completed", message="done with context", prompt="")
+
+    import unittest.mock as mock
+    with mock.patch.object(Agent, "run", patched_run):
+        root = host.get_agent("root")
+
+        def fake_resolve_callback(*, caller_id, callee, prompt):
+            return "the answer is 42"
+
+        with mock.patch.object(AgentHost, "resolve_callback", side_effect=fake_resolve_callback):
+            specs = (SubagentCallSpec(subagent_id="asker", output_key="ask_key"),)
+            results = host.call_subagent_batch(
+                caller=root, specs=specs, mode="parallel",
+                timeout_seconds=10, parent_run_id="test-session.p1.root"
+            )
+
+    assert results[0].status == "completed"
+    assert len(seen_conversation) == 1
+    resumed = seen_conversation[0]
+    # Must include the saved assistant message AND the callback answer.
+    contents = [m["content"] for m in resumed]
+    assert "thinking..." in contents
+    assert "the answer is 42" in contents
+
+
+# ---------------------------------------------------------------------------
+# 15. Hierarchical run IDs
+# ---------------------------------------------------------------------------
+
+def test_hierarchical_run_ids(tmp_path: Path):
+    agents_dir = tmp_path / "agents"
+    write_agent(agents_dir, "root", subagents=["child"])
+    write_agent(agents_dir, "child")
+
+    host = make_host(tmp_path, agents_dir=agents_dir)
+
+    observed_ids: dict[str, str] = {}
+    from agent_framework.agents.agent import Agent
+    original_run = Agent.run
+
+    def patched_run(self, *, host, run_id=None, **kwargs):
+        actual_run = original_run(self, host=host, run_id=run_id, **kwargs)
+        return actual_run
+
+    driver = FakeModelDriver([
+        {"kind": "call_subagent", "subagent_id": "child", "parameters": {}},
+        {"kind": "final_message", "message": "child done"},
+        {"kind": "final_message", "message": "root done"},
+    ])
+    host.model_driver = driver
+
+    # Patch _create_run to observe generated run_ids.
+    original_create_run = Agent._create_run
+
+    def patched_create_run(self, parameters, *, run_id=None, **kwargs):
+        run = original_create_run(self, parameters, run_id=run_id, **kwargs)
+        observed_ids[self.agent_id] = run.run_id
+        return run
+
+    import unittest.mock as mock
+    with mock.patch.object(Agent, "_create_run", patched_create_run):
+        result = host.run_agent("root")
+
+    assert result.status == "completed"
+
+    root_id = observed_ids.get("root", "")
+    child_id = observed_ids.get("child", "")
+
+    # Root ID must match {session}.p{n}.root format.
+    assert root_id.startswith(host.session_id), f"root_id={root_id} should start with session_id"
+    assert ".p1.root" in root_id
+
+    # Child ID must be scoped under root.
+    assert child_id.startswith(root_id), f"child_id={child_id} should start with root_id={root_id}"
+    assert "child" in child_id
+
+    # IDs are distinct.
+    assert root_id != child_id
+
+
+# ---------------------------------------------------------------------------
+# 16. Checkpoint cleanup removes old entries
+# ---------------------------------------------------------------------------
+
+def test_cleanup_checkpoints_removes_old(tmp_path: Path):
+    host = make_host(tmp_path)
+    host.save_checkpoint("run-1", [{"role": "user", "content": "hi"}])
+    host.save_checkpoint("run-2", [{"role": "user", "content": "hello"}])
+
+    # Force timestamps to be old.
+    with host._checkpoint_lock:
+        for key in host._checkpoints:
+            msgs, _ = host._checkpoints[key]
+            host._checkpoints[key] = (msgs, 0.0)
+
+    removed = host.cleanup_checkpoints(ttl_seconds=1.0)
+    assert removed == 2
+    assert host.load_checkpoint("run-1") is None
+    assert host.load_checkpoint("run-2") is None
+
+
+# ---------------------------------------------------------------------------
+# 17. JSONL subscriber is thread-safe under parallel writes
+# ---------------------------------------------------------------------------
+
+def test_jsonl_subscriber_thread_safe(tmp_path: Path):
+    from agent_framework.tracing_subscribers.jsonl_subscriber import JsonlTraceSubscriber
+    from agent_framework.tracing import make_trace_event
+
+    log_path = tmp_path / "trace.jsonl"
+    subscriber = JsonlTraceSubscriber(log_path)
+
+    n_threads = 8
+    events_per_thread = 20
+    errors: list[Exception] = []
+
+    def write_events(thread_idx: int):
+        try:
+            for i in range(events_per_thread):
+                evt = make_trace_event(
+                    kind="test.event",
+                    title=f"t{thread_idx}-e{i}",
+                    channel="runtime",
+                    level="info",
+                )
+                subscriber.consume(evt)
+        except Exception as exc:
+            errors.append(exc)
+
+    threads = [threading.Thread(target=write_events, args=(i,)) for i in range(n_threads)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert not errors, f"Errors during concurrent writes: {errors}"
+
+    lines = log_path.read_text(encoding="utf-8").strip().splitlines()
+    assert len(lines) == n_threads * events_per_thread, f"Expected {n_threads * events_per_thread} lines, got {len(lines)}"
+
+    # Every line must be valid JSON.
+    for i, line in enumerate(lines):
+        try:
+            json.loads(line)
+        except json.JSONDecodeError as exc:
+            pytest.fail(f"Line {i} is not valid JSON: {exc}\nContent: {line[:200]}")


### PR DESCRIPTION
## Summary

- Adds `call_subagents` (plural) as a new closed-set decision kind — dispatch a batch of child agents in one model turn, `parallel` or `sequential`, with configurable wall-clock timeout
- Hierarchical run IDs `{session}.p{n}.{agent_id}.{output_key}` for end-to-end traceability
- Callback resume: blocked parallel child checkpoints conversation history; parent resolves callback and restarts child with full context intact (up to `SUBAGENT_BATCH_MAX_CALLBACK_ROUNDS` rounds)
- Thread-safe JSONL trace subscriber under parallel fan-out
- Periodic checkpoint cleanup via `AgentHost.cleanup_checkpoints(ttl_seconds)`

## New env vars

| Variable | Default | Description |
|---|---|---|
| `SUBAGENT_BATCH_TIMEOUT_SECONDS` | `300` | Wall-clock deadline per batch |
| `SUBAGENT_MAX_PARALLELISM` | `8` | Max entries per `call_subagents` decision |
| `SUBAGENT_BATCH_MAX_CALLBACK_ROUNDS` | `5` | Max callback-resolve-resume rounds |

## Test plan

- [x] `pytest tests/test_parallel_subagents.py` — 17/17 pass
- [x] Full suite — 392 passed, 16 pre-existing failures (`test_dial_driver`/`test_tool_parameters_schema`, require `[dial]` extra)
- [ ] Manual smoke: `python -m agent_framework --instruction "fan out to A, B, C in parallel" --llm-trace file`

Closes #11

https://claude.ai/code/session_01CnuoYKfDBNeHdFoiHFC6fA