### PR TITLE
feat(evaluator-ui): structural trace nesting, batch containers, Flow tab, typed events

### DIFF
--- a/src/agent_framework_evaluator/web/app.js
+++ b/src/agent_framework_evaluator/web/app.js
@@ -43,9 +43,11 @@ const evaluationDetailClose = document.getElementById("evaluation-detail-close")
 const tabChat = document.getElementById("tab-chat");
 const tabEvaluation = document.getElementById("tab-evaluation");
 const tabAgent = document.getElementById("tab-agent");
+const tabFlow = document.getElementById("tab-flow");
 const panelChat = document.getElementById("tab-panel-chat");
 const panelEvaluation = document.getElementById("tab-panel-evaluation");
 const panelAgent = document.getElementById("tab-panel-agent");
+const panelFlow = document.getElementById("tab-panel-flow");
 const agentPromptDisplay = document.getElementById("agent-prompt-display");
 const agentPromptEmpty = document.getElementById("agent-prompt-empty");
 const agentPromptRaw = document.getElementById("agent-prompt-raw");
@@ -106,8 +108,14 @@ const CASE_RUN_HOLD_MS = 450;
 /** @type {HTMLElement | null} */
 let typingPlaceholderEl = null;
 
-/** @type {Map<string, { details: HTMLElement, body: HTMLElement, spinner: HTMLElement, statusEl: HTMLElement, labelEl: HTMLElement, subEl: HTMLElement, agentName: string, lastStatus: string | null, depth: number }>} */
+/** @type {Map<string, { details: HTMLElement, body: HTMLElement, spinner: HTMLElement, statusEl: HTMLElement, labelEl: HTMLElement, subEl: HTMLElement, agentName: string, lastStatus: string | null, depth: number, parentRunId: string | null, batchId: string | null }>} */
 const runFrames = new Map();
+
+/** @type {Map<string, { wrap: HTMLElement, childrenEl: HTMLElement, label: HTMLElement, mode: string, parentRunId: string, childRunIds: string[] }>} */
+const batchFrames = new Map();
+
+/** Maps parent run_id → currently active batch_id for that run. @type {Map<string, string>} */
+const activeBatchForRun = new Map();
 
 /** @type {{ el: HTMLElement, event: Record<string, unknown> }[]} */
 const unifiedEntries = [];
@@ -1302,10 +1310,13 @@ function applyRowPadding(el, depth) {
 function clearTraceUi() {
   if (traceFeed) traceFeed.innerHTML = "";
   runFrames.clear();
+  batchFrames.clear();
+  activeBatchForRun.clear();
   unifiedEntries.length = 0;
   if (conversationThread) conversationThread.innerHTML = "";
   removeTypingPlaceholder();
   setAwaitingPrompt(null);
+  rebuildFlowTab();
 }
 
 /** @type {string | null} */
@@ -1506,6 +1517,28 @@ async function postUserInputHttp(text) {
   refreshComposerState();
 }
 
+function resolveRunContainer(runId) {
+  if (runId && runFrames.has(runId)) {
+    return runFrames.get(runId).body;
+  }
+  return traceFeed;
+}
+
+/** Returns { icon, cssClass } for a runtime event kind. */
+function classifyEventKind(kind) {
+  if (!kind) return null;
+  if (kind.includes("tool_call")) return { icon: "🔧", cssClass: "trace-event--tool" };
+  if (kind.includes("subagent_call")) return { icon: "↳", cssClass: "trace-event--subagent" };
+  if (kind.includes("callback") || kind.includes("callback_requested") || kind.includes("callback_answered")) {
+    return { icon: "↑", cssClass: "trace-event--callback" };
+  }
+  if (kind.includes("skill")) return { icon: "✦", cssClass: "trace-event--skill" };
+  if (kind.includes("decision")) return { icon: "◎", cssClass: "trace-event--decision" };
+  if (kind.includes("model_call")) return { icon: "⊡", cssClass: "trace-event--model" };
+  if (kind.includes("context_updated")) return { icon: "≡", cssClass: "trace-event--context" };
+  return null;
+}
+
 function appendLogLine(event) {
   const entryEvent = {
     ...event,
@@ -1633,7 +1666,6 @@ function beginAgentCallFrame(event) {
 
   const details = document.createElement("details");
   details.className = "trace-agent-call trace-agent-call--running trace-feed-row";
-  applyRowPadding(details, depth);
   details.open = false;
 
   const summary = document.createElement("summary");
@@ -1667,7 +1699,15 @@ function beginAgentCallFrame(event) {
 
   details.appendChild(summary);
   details.appendChild(body);
-  traceFeed.appendChild(details);
+
+  const activeBatchId = parentRunId ? activeBatchForRun.get(parentRunId) : null;
+  let container = traceFeed;
+  if (activeBatchId && batchFrames.has(activeBatchId)) {
+    container = batchFrames.get(activeBatchId).childrenEl;
+  } else if (parentRunId && runFrames.has(parentRunId)) {
+    container = runFrames.get(parentRunId).body;
+  }
+  container.appendChild(details);
 
   runFrames.set(runId, {
     details,
@@ -1679,7 +1719,15 @@ function beginAgentCallFrame(event) {
     agentName,
     lastStatus: null,
     depth,
+    parentRunId: parentRunId || null,
+    batchId: activeBatchId || null,
   });
+
+  if (activeBatchId && batchFrames.has(activeBatchId)) {
+    const bf = batchFrames.get(activeBatchId);
+    if (!bf.childRunIds) bf.childRunIds = [];
+    bf.childRunIds.push(runId);
+  }
 
   const entry = { el: details, event };
   unifiedEntries.push(entry);
@@ -1700,6 +1748,70 @@ function endAgentCallFrame(event) {
   if (fr.details.classList.contains("trace-agent-call--running")) {
     applyFrameOutcome(fr.details, fr, fr.lastStatus || "completed");
   }
+  rebuildFlowTab();
+}
+
+function beginBatchFrame(event) {
+  const ctx = getContext(event);
+  const runId = typeof ctx.run_id === "string" ? ctx.run_id : null;
+  const p = getPayload(event);
+  const batchEvent = p.event && typeof p.event === "object" ? p.event : {};
+  const batchId = typeof batchEvent.batch_id === "string" ? batchEvent.batch_id : null;
+  const mode = typeof batchEvent.mode === "string" ? batchEvent.mode : "parallel";
+  const count = typeof batchEvent.count === "number" ? batchEvent.count : 0;
+  if (!batchId || !runId) return;
+
+  const wrap = document.createElement("div");
+  wrap.className = `trace-batch trace-batch--${mode} trace-batch--running`;
+  wrap.dataset.batchId = batchId;
+
+  const header = document.createElement("div");
+  header.className = "trace-batch-header";
+  const modeIcon = mode === "parallel" ? "⊕" : "→";
+  const label = document.createElement("span");
+  label.className = "trace-batch-label";
+  label.textContent = `${modeIcon} ${mode}: ${count} agent${count !== 1 ? "s" : ""}`;
+  header.appendChild(label);
+
+  const childrenEl = document.createElement("div");
+  childrenEl.className = `trace-batch-children trace-batch-children--${mode}`;
+
+  wrap.appendChild(header);
+  wrap.appendChild(childrenEl);
+
+  const parentFrame = runFrames.get(runId);
+  const container = parentFrame ? parentFrame.body : traceFeed;
+  container.appendChild(wrap);
+
+  batchFrames.set(batchId, { wrap, childrenEl, label, mode, parentRunId: runId, childRunIds: [] });
+  activeBatchForRun.set(runId, batchId);
+
+  const entry = { el: wrap, event };
+  unifiedEntries.push(entry);
+  setEntryVisible(entry);
+  traceFeed.scrollTop = traceFeed.scrollHeight;
+}
+
+function endBatchFrame(event) {
+  const ctx = getContext(event);
+  const runId = typeof ctx.run_id === "string" ? ctx.run_id : null;
+  const p = getPayload(event);
+  const batchEvent = p.event && typeof p.event === "object" ? p.event : {};
+  const batchId = typeof batchEvent.batch_id === "string" ? batchEvent.batch_id : null;
+  const status = typeof batchEvent.status === "string" ? batchEvent.status : "ok";
+  if (!batchId) return;
+
+  const bf = batchFrames.get(batchId);
+  if (bf) {
+    bf.wrap.classList.remove("trace-batch--running");
+    bf.wrap.classList.add(status === "ok" ? "trace-batch--success" : "trace-batch--error");
+    const completed = typeof batchEvent.completed === "number" ? batchEvent.completed : 0;
+    const failed = typeof batchEvent.failed === "number" ? batchEvent.failed : 0;
+    const timedOut = typeof batchEvent.timed_out === "number" ? batchEvent.timed_out : 0;
+    bf.label.textContent = `${bf.mode === "parallel" ? "⊕" : "→"} ${bf.mode}: ${completed} ok${failed ? `, ${failed} failed` : ""}${timedOut ? `, ${timedOut} timed out` : ""}`;
+  }
+  if (runId) activeBatchForRun.delete(runId);
+  rebuildFlowTab();
 }
 
 function onAgentFinished(event) {
@@ -1717,13 +1829,17 @@ function onAgentFinished(event) {
 
 function buildTraceDetails(event) {
   const node = document.createElement("details");
-  node.className = "trace-event-row trace-feed-row";
-  const d = depthForTraceEvent(event);
-  applyRowPadding(node, d);
-  const summary = document.createElement("summary");
-  const ch = typeof event.channel === "string" ? event.channel : "";
+  const kind = typeof event.kind === "string" ? event.kind : "";
   const lvl = typeof event.level === "string" ? event.level : "";
-  summary.textContent = `${ch ? `[${ch}] ` : ""}${event.kind}: ${event.title}`;
+  const classification = classifyEventKind(kind);
+  let rowClass = "trace-event-row trace-feed-row";
+  if (classification) rowClass += ` ${classification.cssClass}`;
+  if (lvl === "error") rowClass += " trace-event--error";
+  node.className = rowClass;
+  const ch = typeof event.channel === "string" ? event.channel : "";
+  const summary = document.createElement("summary");
+  const prefix = classification ? `${classification.icon} ` : (ch ? `[${ch}] ` : "");
+  summary.textContent = `${prefix}${event.kind}: ${event.title}`;
   if (lvl) {
     const badge = document.createElement("span");
     badge.className = `trace-level-badge trace-level-${lvl}`;
@@ -1748,11 +1864,102 @@ function appendTraceEventRow(event) {
   const node = buildTraceDetails(entryEvent);
   node.dataset.channel = entryEvent.channel;
   node.dataset.level = entryEvent.level;
-  traceFeed.appendChild(node);
+  const rid = getEventRunId(entryEvent);
+  const p = getPayload(entryEvent);
+  const pr = p.parent_run_id != null && p.parent_run_id !== "" ? String(p.parent_run_id) : null;
+  const container = resolveRunContainer(rid || pr);
+  container.appendChild(node);
   const entry = { el: node, event: entryEvent };
   unifiedEntries.push(entry);
   setEntryVisible(entry);
   traceFeed.scrollTop = traceFeed.scrollHeight;
+}
+
+function buildFlowNode(runId, depth) {
+  const fr = runFrames.get(runId);
+  if (!fr) return null;
+
+  const node = document.createElement("div");
+  node.className = "flow-node";
+  node.style.marginLeft = `${depth * 20}px`;
+
+  const pill = document.createElement("button");
+  pill.type = "button";
+  pill.className = `flow-pill${fr.lastStatus === "completed" || fr.lastStatus === null ? " flow-pill--success" : fr.lastStatus === "failed" ? " flow-pill--error" : " flow-pill--neutral"}`;
+  pill.textContent = fr.agentName;
+  pill.title = `run: ${runId}`;
+  pill.addEventListener("click", () => {
+    fr.details.scrollIntoView({ behavior: "smooth", block: "nearest" });
+    fr.details.open = true;
+    fr.details.classList.add("flow-highlight");
+    setTimeout(() => fr.details.classList.remove("flow-highlight"), 1500);
+  });
+  node.appendChild(pill);
+
+  const childrenWithBatch = [];
+  for (const [bid, bf] of batchFrames) {
+    if (bf.parentRunId === runId) {
+      childrenWithBatch.push({ type: "batch", batchId: bid, bf });
+    }
+  }
+  const batchChildRunIds = new Set();
+  for (const { bf } of childrenWithBatch) {
+    for (const cid of (bf.childRunIds || [])) batchChildRunIds.add(cid);
+  }
+  const singleChildren = [];
+  for (const [cid, cfr] of runFrames) {
+    if (cfr.parentRunId === runId && !batchChildRunIds.has(cid)) {
+      singleChildren.push(cid);
+    }
+  }
+
+  for (const { batchId, bf } of childrenWithBatch) {
+    const batchWrap = document.createElement("div");
+    batchWrap.className = `flow-batch flow-batch--${bf.mode}`;
+    batchWrap.style.marginLeft = `${(depth + 1) * 20}px`;
+    const batchLabel = document.createElement("span");
+    batchLabel.className = "flow-batch-label";
+    batchLabel.textContent = `${bf.mode === "parallel" ? "⊕" : "→"} ${bf.mode}`;
+    batchWrap.appendChild(batchLabel);
+    const batchRow = document.createElement("div");
+    batchRow.className = `flow-batch-row flow-batch-row--${bf.mode}`;
+    for (const cid of (bf.childRunIds || [])) {
+      const childNode = buildFlowNode(cid, 0);
+      if (childNode) batchRow.appendChild(childNode);
+    }
+    batchWrap.appendChild(batchRow);
+    node.appendChild(batchWrap);
+  }
+
+  for (const cid of singleChildren) {
+    const childNode = buildFlowNode(cid, depth + 1);
+    if (childNode) node.appendChild(childNode);
+  }
+
+  return node;
+}
+
+function rebuildFlowTab() {
+  const panel = document.getElementById("tab-panel-flow");
+  if (!panel) return;
+  const flowTree = panel.querySelector(".flow-tree");
+  if (!flowTree) return;
+  while (flowTree.firstChild) flowTree.removeChild(flowTree.firstChild);
+
+  if (runFrames.size === 0) {
+    const empty = document.createElement("p");
+    empty.className = "flow-empty";
+    empty.textContent = "No agent runs yet.";
+    flowTree.appendChild(empty);
+    return;
+  }
+
+  for (const [runId, fr] of runFrames) {
+    if (!fr.parentRunId) {
+      const node = buildFlowNode(runId, 0);
+      if (node) flowTree.appendChild(node);
+    }
+  }
 }
 
 function routeTraceEvent(event) {
@@ -1778,6 +1985,20 @@ function routeTraceEvent(event) {
   if (kind === "runtime.audit.agent_call_finished") {
     endAgentCallFrame(event);
     return;
+  }
+
+  if (kind === "runtime.audit.named_event") {
+    const p = getPayload(event);
+    const batchEvent = p.event && typeof p.event === "object" ? p.event : {};
+    const eventType = typeof batchEvent.type === "string" ? batchEvent.type : "";
+    if (eventType === "subagent_batch_started") {
+      beginBatchFrame(event);
+      return;
+    }
+    if (eventType === "subagent_batch_finished") {
+      endBatchFrame(event);
+      return;
+    }
   }
 
   if (kind === "runtime.agent_finished") {
@@ -2182,6 +2403,7 @@ function setActiveTab(which) {
     { id: "chat", btn: tabChat, panel: panelChat },
     { id: "evaluation", btn: tabEvaluation, panel: panelEvaluation },
     { id: "agent", btn: tabAgent, panel: panelAgent },
+    { id: "flow", btn: tabFlow, panel: panelFlow },
   ];
   for (const t of tabs) {
     const active = t.id === which;
@@ -2197,11 +2419,15 @@ function setActiveTab(which) {
   if (which === "agent") {
     void refreshAgentPromptView();
   }
+  if (which === "flow") {
+    rebuildFlowTab();
+  }
 }
 
 tabChat?.addEventListener("click", () => setActiveTab("chat"));
 tabEvaluation?.addEventListener("click", () => setActiveTab("evaluation"));
 tabAgent?.addEventListener("click", () => setActiveTab("agent"));
+tabFlow?.addEventListener("click", () => setActiveTab("flow"));
 
 let agentPromptMode = "raw";
 let cachedRawSystemPrompt = "";

--- a/src/agent_framework_evaluator/web/index.html
+++ b/src/agent_framework_evaluator/web/index.html
@@ -46,6 +46,7 @@
       <div class="main-tabs" role="tablist" aria-label="Main panels">
         <button type="button" class="main-tab main-tab--active" role="tab" aria-selected="true" aria-controls="tab-panel-chat" id="tab-chat">Chat</button>
         <button type="button" class="main-tab" role="tab" aria-selected="false" aria-controls="tab-panel-evaluation" id="tab-evaluation">Evaluation</button>
+        <button type="button" class="main-tab" role="tab" aria-selected="false" aria-controls="tab-panel-flow" id="tab-flow">Flow</button>
         <button type="button" class="main-tab" role="tab" aria-selected="false" aria-controls="tab-panel-agent" id="tab-agent">Agent</button>
       </div>
       <div id="tab-panel-chat" class="tab-panel tab-panel--active" role="tabpanel" aria-labelledby="tab-chat">
@@ -114,6 +115,12 @@
               </div>
             </div>
           </div>
+        </div>
+      </div>
+      <div id="tab-panel-flow" class="tab-panel tab-panel--flow" role="tabpanel" aria-labelledby="tab-flow" hidden>
+        <div class="flow-tab-inner">
+          <p class="flow-tab-hint">Structural view of agent execution. Click a node to highlight it in the Trace panel.</p>
+          <div class="flow-tree" aria-label="Agent call tree"></div>
         </div>
       </div>
       <div id="tab-panel-agent" class="tab-panel tab-panel--agent" role="tabpanel" aria-labelledby="tab-agent" hidden>

--- a/src/agent_framework_evaluator/web/styles.css
+++ b/src/agent_framework_evaluator/web/styles.css
@@ -1890,3 +1890,170 @@ body {
   font-size: 0.84rem;
 }
 
+/* ── Typed event rows ──────────────────────────────────────── */
+
+.trace-event--tool > summary { border-left-color: #d4a030; }
+.trace-event--tool { border-left-color: #d4a030; }
+
+.trace-event--callback > summary { border-left-color: #e07040; }
+.trace-event--callback { border-left-color: #e07040; }
+
+.trace-event--skill > summary { border-left-color: #7090b0; }
+.trace-event--skill { border-left-color: #7090b0; }
+
+.trace-event--decision > summary { border-left-color: #8888bb; }
+.trace-event--decision { border-left-color: #8888bb; }
+
+.trace-event--model > summary { border-left-color: #446677; }
+.trace-event--model { border-left-color: #446677; }
+
+.trace-event--error { border-left-color: #c05050; background: rgba(200, 80, 80, 0.08); }
+
+.trace-event--subagent > summary { border-left-color: #40a0a0; }
+.trace-event--subagent { border-left-color: #40a0a0; }
+
+/* ── Batch containers ──────────────────────────────────────── */
+
+.trace-batch {
+  margin: 0.4rem 0;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 0.35rem 0.5rem;
+  background: rgba(20, 30, 45, 0.5);
+}
+
+.trace-batch--running { border-color: rgba(91, 192, 222, 0.4); }
+.trace-batch--success { border-color: rgba(80, 160, 120, 0.5); }
+.trace-batch--error   { border-color: rgba(200, 90, 90, 0.5); }
+
+.trace-batch-header {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--muted);
+  margin-bottom: 0.4rem;
+  padding-bottom: 0.25rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.trace-batch-label { letter-spacing: 0.02em; }
+
+.trace-batch-children--parallel {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  align-items: flex-start;
+}
+
+.trace-batch-children--parallel > .trace-agent-call {
+  flex: 1 1 200px;
+  min-width: 180px;
+  max-width: 420px;
+}
+
+.trace-batch-children--sequential {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+/* ── Flow tab ─────────────────────────────────────────────── */
+
+.tab-panel--flow {
+  overflow-y: auto;
+  padding: 1rem 1.25rem;
+}
+
+.flow-tab-inner {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  height: 100%;
+}
+
+.flow-tab-hint {
+  margin: 0;
+  font-size: 0.8rem;
+  color: var(--muted);
+}
+
+.flow-tree {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  padding: 0.25rem 0;
+}
+
+.flow-empty {
+  color: var(--muted);
+  font-size: 0.85rem;
+  margin: 0;
+}
+
+.flow-node {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.flow-pill {
+  display: inline-block;
+  padding: 0.2rem 0.65rem;
+  border-radius: 999px;
+  font-size: 0.82rem;
+  font-weight: 600;
+  border: 1.5px solid var(--border);
+  background: var(--panel);
+  color: var(--text);
+  cursor: pointer;
+  transition: border-color 0.15s, background 0.15s;
+  white-space: nowrap;
+}
+
+.flow-pill:hover { border-color: var(--accent); background: rgba(91, 192, 222, 0.1); }
+.flow-pill--success { border-color: rgba(80, 160, 120, 0.55); }
+.flow-pill--error   { border-color: rgba(200, 90, 90, 0.55); }
+.flow-pill--neutral { border-color: var(--border); }
+
+.flow-batch {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  padding: 0.3rem 0.5rem;
+  border: 1px dashed var(--border);
+  border-radius: 6px;
+  background: rgba(20, 30, 45, 0.35);
+}
+
+.flow-batch-label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--muted);
+  letter-spacing: 0.03em;
+}
+
+.flow-batch-row--parallel {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: flex-start;
+}
+
+.flow-batch-row--sequential {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+/* Highlight animation when scrolled-to from flow tab */
+@keyframes flow-highlight-pulse {
+  0%   { outline-color: var(--accent); }
+  50%  { outline-color: rgba(91,192,222,0.8); }
+  100% { outline-color: transparent; }
+}
+
+.flow-highlight {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  animation: flow-highlight-pulse 1.5s ease-out forwards;
+}
+


### PR DESCRIPTION
Closes #23

## Summary

- **Fix DOM nesting (core bug)**: trace events and child agent frames now insert into their parent run's `.body` element instead of always appending flat to `#trace-feed`. Expand/collapse on agent call frames now works correctly — collapsing hides all events belonging to that run.
- **Batch containers**: `subagent_batch_started/finished` named events create visual group frames inside the parent agent frame. Parallel batches render children side-by-side in a flex row; sequential batches stack vertically.
- **Typed event row icons**: runtime events carry distinct icons and left-border colors — `⊡` model calls, `◎` decisions, `≡` context updates, `🔧` tool calls, `↑` callbacks, `✦` skills, `↳` subagent calls.
- **Flow tab**: new structural bird's-eye view of the agent call tree. Parallel batch children shown on the same row. Click any pill to scroll-and-highlight the corresponding trace frame in the right panel.

## Technical details

- Added `batchFrames` Map (batch_id → frame) and `activeBatchForRun` Map (parent_run_id → active batch_id) to route child agent frames into the correct batch container.
- `resolveRunContainer(runId)` returns the run's `.body` div if a frame exists, else falls back to `traceFeed`.
- `beginAgentCallFrame` checks `activeBatchForRun` and `runFrames` to pick the right container for each new child frame.
- `rebuildFlowTab()` rebuilds the flow tree on each `agent_call_finished` or `subagent_batch_finished` event.
- No backend changes — all changes are in `app.js`, `index.html`, `styles.css`.

## Test plan

- [ ] Run a test case with `player_intent_parser` initializer; confirm agent call frame collapses/expands correctly with events inside
- [ ] Verify typed event icons appear (`⊡`, `◎`, `≡`) in trace rows
- [ ] Open Flow tab; confirm agent pill appears; click it to highlight trace frame
- [ ] (For parallel sub-agents) Run a `call_subagents` batch; confirm batch container appears with mode label and children side-by-side

🤖 Generated with [Claude Code](https://claude.com/claude-code)