### PR TITLE
FEAT #76: split message / response + extract BaseTurnDriver

### DIFF
--- a/docs/planning-implementation-status.md
+++ b/docs/planning-implementation-status.md
@@ -30,11 +30,16 @@ This document captures the exact state of implementation so an incoming agent ca
 | #65 | Safety caps and plan validation error recovery — `max_steps`, `max_plan_revisions` caps with 80% warnings; step exception handling; consecutive validation failure recovery | `src/agent_framework/planning/turn_driver.py`, `src/agent_framework/planning/plan_state.py`, `tests/planning/test_planning_turn_driver_safety.py` |
 | #66 | `system.plan_execute.md` — planning system prompt template; `response_mode: plan_execute`; `build_context` wiring | `src/agent_framework/agents/system.plan_execute.md`, `src/agent_framework/model.py`, `src/agent_framework/agents/agent.py`, `tests/planning/test_system_plan_execute.md` |
 
+### Done — merged into `feature/planning-support`
+
+| FEAT | Description | Key files |
+|------|-------------|-----------|
+| #67 | `player_controller` planning integration — rewrote agent with `planning: enabled: true`; two-phase plan (parallel retrieval + intent parsing → object details + routing); committed to agent-adventure `main` | `agent-adventure/agents/player_controller.md` |
+
 ### Not done
 
 | FEAT / Issue | Description | Notes |
 |---|---|---|
-| #67 | End-to-end integration with `player_controller` | Update `player_controller.md` frontmatter to add `planning: enabled: true`. Run existing evaluator suite, compare against baseline. See ADR §16. |
 | #74 | Review planning documentation — TOC presence and reading narrative | Review `docs/architecture/adr-planning.md` for TOC and narrative completeness. |
 
 ---

--- a/docs/research/issue-76-message-response-split.md
+++ b/docs/research/issue-76-message-response-split.md
@@ -1,0 +1,100 @@
+# Issue #76: Structured response field instead of serialized JSON `message`
+
+## Summary
+
+**Recommendation: introduce a first-class `response` field on `AgentResult` and `AgentDecision`, orthogonal to `message`, and remove the current practice of serializing structured output into `message`.**
+
+## Problem
+
+The current `AgentResult.message` / `AgentResult.parameters` contract conflates two concerns:
+
+1. **Human-readable prose** — a natural-language summary for the caller (parent agent, evaluator, or user).
+2. **Structured payload** — typed output the caller processes programmatically.
+
+These are served by the same `message` field today, via a three-layer encoding:
+
+- `system.json_object.md:75-76` instructs the model: "If `parameters` is populated, `message` must contain the serialized JSON (escaped as string). In this case, `parameters.message` may hold a user-facing message."
+- `_subagent_result_payload` (`agents/agent.py:152-176`) re-wraps `{message, ...params}` into JSON again when forwarding to a parent conversation: `json.dumps({"message": message, **parameters})`.
+- The evaluator's `select_agent_result_field` must then parse `message` as JSON to extract structured fields, or fall back to `parameters` depending on `injection_mode`.
+
+The resulting failure modes observed in planning rollout:
+
+- Models emit `parameters` without re-serializing them into `message` (or vice versa) — either the prose disappears from the caller's view or the structured payload is unreachable.
+- Parent agents receiving a subagent result see a JSON string where they expected prose, requiring a second parse.
+- `AgentDecision.parameters` (tool/subagent *call inputs*) and `AgentResult.parameters` (structured *output*) share the same field name with different semantics — contributors conflate them, models conflate them.
+
+## Proposed contract
+
+| Field | Type | Responsibility |
+|---|---|---|
+| `message` | `str` | Human-readable text only. **Never** holds JSON. Required for text-mode agents. |
+| `response` | `dict[str, Any] \| None` | The structured payload. Replaces `AgentResult.parameters`. |
+
+Rules:
+- The framework **never** auto-serializes `response` into `message` or vice versa.
+- A model emitting a `final_message` with structured output sets `response`. A model emitting prose sets `message`. Both fields may be set simultaneously (short prose summary + full structured payload).
+- `AgentDecision.parameters` retains its current meaning (call inputs for tool/subagent decisions). Only the *result* side changes.
+- Subagent handoff emits a typed envelope: `<subagent_result message="...">{json}</subagent_result>`. Parents consume the channel they need.
+
+## Decision rationale
+
+The alternative — keeping a single `message` field — was rejected because:
+- It forces the model to know which serialization mode is active and double-write correctly; models drift from this instruction reliably.
+- Every downstream consumer has to re-parse a string that may or may not be valid JSON, and then decide which of `message`, `parameters`, and `parsed_message` to use as the authoritative value. That is O(consumers × modes) guessing, not a contract.
+- Persistence and tracing store strings; round-trips lose typing and break dot-traversal (`select_agent_result_field`).
+
+## Affected surfaces
+
+| Surface | Change |
+|---|---|
+| `agents/agent_result.py` | Add `response: dict \| None`. Phase 2: remove `parameters`, `parameters_injection`. |
+| `agents/agent_decision.py` | Add `response: dict \| None` to `AgentDecision`. Parser reads `response` first, falls back to `parameters` with deprecation log. |
+| `agents/agent.py` | `_subagent_result_payload` replaced by typed envelope helper. `handle_final_message` populates `response`. |
+| `agents/result_envelope.py` (new) | `render_subagent_envelope(*, message, response) -> str`. |
+| `agents/system*.md` (5 files) | Remove "serialize `parameters` into `message`" instruction. Add "put structured output in `response`". |
+| `planning/turn_driver.py` | `_make_result` populates `response`. Subagent step result extracted via envelope. |
+| `evaluator.py`, `evaluation.py` | `select_agent_result_field` traverses `response.<path>` first, then `parameters.<path>` (Phase 1). `_agent_result_payload` includes `response`. |
+| `audit_trace.py`, `runtime_trace_behavior.py` | Record `response` alongside `message` in trace payloads. |
+| Tests | New `tests/test_agent_response_field.py`. Existing tests updated Phase 2. |
+
+## Migration strategy
+
+### Phase 1 — additive (non-breaking)
+
+- Add `response` field to `AgentResult` and `AgentDecision` (optional, `None` default).
+- Parser: accepts `response` from model output; if absent, mirrors `parameters` into `response` and logs a deprecation warning (no silent swallowing — the warning is observable via log level WARNING).
+- Result builders (`handle_final_message`, `PlanningTurnDriver._make_result`) populate both `response` (from `decision.response`) and `parameters` (mirror) for one release.
+- Envelope helper introduced alongside old `_subagent_result_payload`; old helper routes to envelope when `response` is present.
+- Evaluator: `select_agent_result_field` tries `response.<path>` first, then `parameters.<path>`.
+- System prompts updated to teach the new contract.
+
+### Phase 2 — breaking cleanup
+
+- Drop `AgentResult.parameters` and the mirror.
+- Drop `_subagent_result_payload` and `parameters_injection`.
+- Strict validation: `final_message` with non-empty structured payload must populate `response`; absence raises `ValueError`.
+- System prompts: remove all legacy `parameters` result instructions.
+- Update all tests.
+
+## Decisions made
+
+| Question | Decision |
+|---|---|
+| Type of `response` | `dict[str, Any] \| None` only. Lists/scalars wrap in `{"value": ...}` at the model prompt level. |
+| Callback contract | Unchanged (`kind` + `callback_intent`). Out of scope. |
+| Empty `message` | Required for text mode; optional otherwise; never required to mirror `response`. |
+| Compat window | Two commits (Phase 1 then Phase 2) in the same branch/PR. |
+| `AgentDecision.parameters` | Retained (call inputs). Only the result side changes. |
+
+## Pros and cons
+
+**Pros:**
+- Model instruction is mechanical and unambiguous. No double-write.
+- Evaluator, tracing, and persistence treat structured data as data (not strings).
+- `_subagent_result_payload` and `parameters_injection` disappear; the framework no longer makes semantic decisions about how to merge two opaque bags.
+- `select_agent_result_field` becomes a simple dot-traversal with a well-defined primary target.
+
+**Cons:**
+- Phase 2 is a breaking change on `AgentResult` — any code reading `result.parameters` breaks. Mitigation: Phase 1 mirror + one-release window.
+- System prompt updates require re-testing every agent that relies on the old double-write convention.
+- The typed envelope requires XML parsing on the parent side (or structured tagging); the current string-in-string approach lets the parent treat results as opaque text. Mitigation: envelope is XML-tagged, parseable with standard `re` or `xml.etree`; the existing `<subagent_result>` message shape is already XML-tagged in some prompt templates.

--- a/src/agent_framework/agents/agent.py
+++ b/src/agent_framework/agents/agent.py
@@ -109,23 +109,6 @@ def _emit_context_updated(
     )
 
 
-_PARAMETERS_INJECTION_VALUES = frozenset(("override", "append", "ignore"))
-
-
-def _parse_parameters_injection(raw: Any, source_path: Path | None = None) -> str:
-    """Validate and normalise a ``parameters_injection`` frontmatter value."""
-    if raw is None:
-        return "override"
-    value = str(raw).strip().lower()
-    if value not in _PARAMETERS_INJECTION_VALUES:
-        raise AgentMarkdownError(
-            source_path=source_path or Path("<unknown>"),
-            detail=f"Invalid parameters_injection value {raw!r}.",
-            hint=f"Must be one of: {sorted(_PARAMETERS_INJECTION_VALUES)}",
-        )
-    return value
-
-
 def _parse_planning_config(raw: Any, source_path: Path | None = None) -> "PlanningConfig | None":
     """Parse the optional `planning:` frontmatter block into a PlanningConfig."""
     if raw is None:
@@ -150,47 +133,12 @@ def _parse_planning_config(raw: Any, source_path: Path | None = None) -> "Planni
 
 
 def _render_result_for_injection(result: Any) -> str:
-    """Render an AgentResult for injection into a parent conversation.
-
-    Prefers the typed envelope when *response* is set; falls back to the
-    legacy _subagent_result_payload serialization otherwise.
-    """
+    """Render an AgentResult for injection into a parent conversation."""
     from agent_framework.agents.result_envelope import render_subagent_envelope
-    response = getattr(result, "response", None)
-    if response is not None:
-        return render_subagent_envelope(message=result.message, response=response)
-    return _subagent_result_payload(
-        result.message,
-        getattr(result, "parameters", None),
-        getattr(result, "parameters_injection", "override"),
+    return render_subagent_envelope(
+        message=getattr(result, "message", ""),
+        response=getattr(result, "response", None),
     )
-
-
-def _subagent_result_payload(
-    message: str,
-    parameters: dict[str, Any] | None,
-    injection_mode: str = "override",
-) -> str:
-    """Build the text injected into the parent conversation for a subagent result.
-
-    ``injection_mode`` controls how ``parameters`` are combined with ``message``:
-
-    - ``"override"`` (default): merge into ``{"message": ..., ...params}`` JSON envelope.
-    - ``"append"``: keep ``message`` verbatim, append a fenced JSON block with the
-      parameters so the parent can parse it if needed without losing the prose summary.
-    - ``"ignore"``: return ``message`` unchanged; parameters are not forwarded.
-
-    When there are no parameters the plain message is always returned unchanged.
-    """
-    if not parameters:
-        return message
-    if injection_mode == "ignore":
-        return message
-    if injection_mode == "append":
-        params_text = json.dumps(parameters, ensure_ascii=False)
-        return f"{message}\n```\n{params_text}\n```"
-    # "override" (default)
-    return json.dumps({"message": message, **parameters}, ensure_ascii=False)
 
 
 @dataclass(slots=True)
@@ -255,7 +203,6 @@ class Agent:
     behaviors: tuple[AgentBehavior, ...] = field(default=(), repr=False)
     source_path: Path | None = None
     terminal_tools: tuple[str, ...] = ()
-    parameters_injection: str = "override"
     planning_config: "PlanningConfig | None" = None
 
     @classmethod
@@ -317,9 +264,6 @@ class Agent:
             behavior_ids=behavior_ids,
             source_path=source_path,
             terminal_tools=tuple(metadata.get("terminal_tools", []) or ()),
-            parameters_injection=_parse_parameters_injection(
-                metadata.get("parameters_injection"), source_path
-            ),
             planning_config=_parse_planning_config(metadata.get("planning"), source_path),
         )
         agent._validate_template_contract()
@@ -782,8 +726,6 @@ class Agent:
             status="completed",
             message=decision.message,
             response=decision.response,
-            parameters=decision.parameters if decision.parameters else None,
-            parameters_injection=self.parameters_injection,
             decision=decision,
             prompt=run.rendered_prompt,
         )

--- a/src/agent_framework/agents/agent.py
+++ b/src/agent_framework/agents/agent.py
@@ -149,6 +149,23 @@ def _parse_planning_config(raw: Any, source_path: Path | None = None) -> "Planni
         ) from exc
 
 
+def _render_result_for_injection(result: Any) -> str:
+    """Render an AgentResult for injection into a parent conversation.
+
+    Prefers the typed envelope when *response* is set; falls back to the
+    legacy _subagent_result_payload serialization otherwise.
+    """
+    from agent_framework.agents.result_envelope import render_subagent_envelope
+    response = getattr(result, "response", None)
+    if response is not None:
+        return render_subagent_envelope(message=result.message, response=response)
+    return _subagent_result_payload(
+        result.message,
+        getattr(result, "parameters", None),
+        getattr(result, "parameters_injection", "override"),
+    )
+
+
 def _subagent_result_payload(
     message: str,
     parameters: dict[str, Any] | None,
@@ -764,6 +781,7 @@ class Agent:
         return AgentResult(
             status="completed",
             message=decision.message,
+            response=decision.response,
             parameters=decision.parameters if decision.parameters else None,
             parameters_injection=self.parameters_injection,
             decision=decision,
@@ -1317,7 +1335,7 @@ class Agent:
         )
         if pre_decision.system_message:
             run.prompt_fragments.append(f"<system_message>{pre_decision.system_message}</system_message>")
-        payload = _subagent_result_payload(result.message, result.parameters, result.parameters_injection)
+        payload = _render_result_for_injection(result)
         agent_events.audit_named_event(
             run_id=run.run_id,
             agent_id=self.agent_id,
@@ -1452,11 +1470,7 @@ class Agent:
             attrs = f'key="{r.output_key}" agent_id="{r.subagent_id}" status="{r.status}"'
             if r.status == "blocked" and r.callback_intent:
                 attrs += f' intent="{r.callback_intent}"'
-            payload = _subagent_result_payload(
-                r.message,
-                getattr(r, "parameters", None),
-                getattr(r, "parameters_injection", "override"),
-            )
+            payload = _render_result_for_injection(r)
             if payload:
                 lines.append(f"  <subagent_result {attrs}>{payload}</subagent_result>")
             else:

--- a/src/agent_framework/agents/agent_decision.py
+++ b/src/agent_framework/agents/agent_decision.py
@@ -333,9 +333,10 @@ class AgentDecision:
             decision_response: dict[str, Any] | None = raw_response
         else:
             if normalized_kind == "final_message" and payload.get("parameters"):
-                _LOGGER.warning(
-                    "Deprecated: 'parameters' used as result payload in final_message decision. "
-                    "Set 'response' for structured output; 'parameters' on results will be removed."
+                raise ValueError(
+                    "Invalid model decision JSON: final_message with structured output must use "
+                    "'response' (a JSON object). Setting 'parameters' on a final_message result "
+                    "is no longer supported. Move the structured payload to 'response'."
                 )
             decision_response = None
 

--- a/src/agent_framework/agents/agent_decision.py
+++ b/src/agent_framework/agents/agent_decision.py
@@ -178,6 +178,7 @@ class AgentDecision:
 
     kind: str
     message: str = ""
+    response: dict[str, Any] | None = None
     parameters: dict[str, Any] = field(default_factory=dict)
     subagent_id: str | None = None
     tool_name: str | None = None
@@ -327,9 +328,21 @@ class AgentDecision:
         if normalized_kind in ("submit_plan", "amend_plan"):
             plan = _parse_and_validate_plan(payload)
 
+        raw_response = payload.get("response")
+        if isinstance(raw_response, dict):
+            decision_response: dict[str, Any] | None = raw_response
+        else:
+            if normalized_kind == "final_message" and payload.get("parameters"):
+                _LOGGER.warning(
+                    "Deprecated: 'parameters' used as result payload in final_message decision. "
+                    "Set 'response' for structured output; 'parameters' on results will be removed."
+                )
+            decision_response = None
+
         return cls(
             kind=normalized_kind,
             message=str(payload.get("message", "")).strip(),
+            response=decision_response,
             parameters=dict(payload.get("parameters", {}) or {}),
             subagent_id=subagent_id,
             tool_name=tool_name,

--- a/src/agent_framework/agents/agent_result.py
+++ b/src/agent_framework/agents/agent_result.py
@@ -16,8 +16,6 @@ class AgentResult:
     status: str
     message: str = ""
     response: dict[str, Any] | None = None
-    parameters: dict[str, Any] | None = None
-    parameters_injection: str = "override"
     decision: AgentDecision | None = None
     prompt: str = ""
     context: CallContext | None = None

--- a/src/agent_framework/agents/agent_result.py
+++ b/src/agent_framework/agents/agent_result.py
@@ -15,6 +15,7 @@ class AgentResult:
 
     status: str
     message: str = ""
+    response: dict[str, Any] | None = None
     parameters: dict[str, Any] | None = None
     parameters_injection: str = "override"
     decision: AgentDecision | None = None

--- a/src/agent_framework/agents/agent_run.py
+++ b/src/agent_framework/agents/agent_run.py
@@ -35,5 +35,6 @@ class AgentRun:
     memory_projection_requests: tuple[str, ...] = ()
     in_parallel_batch: bool = False
     plan_state: "PlanState | None" = None
+    consecutive_validation_failures: int = 0
 
 __all__ = ["AgentRun"]

--- a/src/agent_framework/agents/result_envelope.py
+++ b/src/agent_framework/agents/result_envelope.py
@@ -1,0 +1,36 @@
+"""Typed envelope for subagent results.
+
+Replaces the ad-hoc serialization that mixed human-readable message and
+structured response into a single string.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+
+def render_subagent_envelope(*, message: str, response: dict[str, Any] | None) -> str:
+    """Render a typed subagent result envelope.
+
+    When *response* is ``None`` the plain *message* is returned unchanged for
+    backward-compat with callers that treat the result as a prose string.
+
+    When *response* is set the envelope format is::
+
+        <subagent_result message="...escaped...">
+        {"json": "payload"}
+        </subagent_result>
+
+    Parent agents can extract whichever channel they need:
+    - Prose summary: read the ``message`` attribute.
+    - Structured payload: parse the element text content as JSON.
+    """
+    if response is None:
+        return message
+    escaped_message = message.replace('"', "&quot;").replace("\n", "&#10;")
+    response_json = json.dumps(response, ensure_ascii=False)
+    return f'<subagent_result message="{escaped_message}">\n{response_json}\n</subagent_result>'
+
+
+__all__ = ["render_subagent_envelope"]

--- a/src/agent_framework/agents/system.decision.md
+++ b/src/agent_framework/agents/system.decision.md
@@ -37,3 +37,8 @@ Example `call_subagents`:
   {"subagent_id": "critic", "parameters": {"topic": "X"}, "output_key": "critique"}
 ]}
 ```
+
+## Output channels for `final_message`
+
+- `message`: Human-readable prose for the caller. Never serialize JSON into this field.
+- `response`: Structured output as a JSON object. Use when the caller needs typed data. Both fields may be set together — prose summary in `message`, full payload in `response`.

--- a/src/agent_framework/agents/system.json_object.md
+++ b/src/agent_framework/agents/system.json_object.md
@@ -4,8 +4,8 @@ Rules:
 1. Return exactly one JSON object.
 2. Do not answer in prose outside the JSON object.
 3. Follow the agent system prompt for the object shape and field semantics.
-4. Always include "kind" in the response
-5. "message" field must contain all user-facing information. DO NOT rely on other json fields to represent user output. 
+4. Always include "kind" in the response.
+5. Use `message` for human-readable text only. Use `response` (a JSON object) for structured output. Never serialize `response` into `message`; they are independent channels.
 6. If the current task is a runtime action selection task, use the structured action object required by the runtime and the current agent system prompt.
 7. If information is missing, do not ask in plain text. Emit the structured callback object required by the current agent system prompt.
 8. If a declared tool or subagent can make progress, prefer using it over a callback.
@@ -14,7 +14,7 @@ Rules:
 
 ## Callbacks
 
-Use a structured interaction object when you cannot complete the task locally and need clarification, caller review, direct user input, approval, or recovery. Put all structured details in both `parameters` (as a JSON object) and `message` (as an escaped JSON string). Put user-facing message into 'parameters.message'.
+Use a structured interaction object when you cannot complete the task locally and need clarification, caller review, direct user input, approval, or recovery. Put all structured details in `parameters` (as a JSON object). Put any user-facing prose in `message`.
 
 1. `intent="information_request"` and `kind="callback"`
    Use when required information is missing, unresolved, or ambiguous and local retrieval has been exhausted, therefore request must be escalated to caller.
@@ -71,6 +71,5 @@ When the current agent system prompt is asking for a runtime action, return a si
     - "call_subagents": dispatch multiple subagents; set "mode" to "parallel" or "sequential" and "calls" to a list of {"subagent_id", "parameters", "output_key"} objects
     - "call_tool": the agent calls a tool. "tool_name" is populated. "parameters" are populated matching the tool specification
     - "invoke_skill": invoke a named skill; set `skill_name` to a valid skill name from `<available_skills>`
-- `message`: MUST contain all information returned by the agent (no other information will be visible to the consumers of the agent). 
-    - If 'parameters' is populated, this field must contain the serialized JSON (escaped as string). In this case, 'parameters.message' may hold an user-facing message
-    - If 'parameters' is not specified or empty, 'message' can contain a direct string to the user.
+- `message`: Human-readable text for the caller. Never holds JSON. Optional when `response` is populated.
+- `response`: Structured output payload as a JSON object. Set this (instead of `message`) when the caller needs typed data. Both fields may be set simultaneously — a short prose summary in `message` and the full structured payload in `response`.

--- a/src/agent_framework/agents/system.plan_execute.md
+++ b/src/agent_framework/agents/system.plan_execute.md
@@ -91,7 +91,12 @@ When a step emits a callback (you see `<pending_callback>`):
   ```json
   {"kind": "continue_plan", "message": "fetch completed, proceeding"}
   ```
-- `final_message` example:
+- `final_message` example (prose only):
   ```json
   {"kind": "final_message", "message": "<synthesized answer>"}
   ```
+- `final_message` example (structured output):
+  ```json
+  {"kind": "final_message", "message": "<short summary>", "response": {"key": "value"}}
+  ```
+  Use `message` for human-readable text only. Use `response` for structured output. Never serialize `response` into `message`.

--- a/src/agent_framework/agents/turn_driver.py
+++ b/src/agent_framework/agents/turn_driver.py
@@ -1,4 +1,4 @@
-"""TurnDriver protocol and StandardTurnDriver implementation.
+"""TurnDriver protocol, BaseTurnDriver, and StandardTurnDriver.
 
 The TurnDriver seam extracts the per-turn loop body from Agent.run, making it
 possible to swap in a PlanningTurnDriver without modifying Agent or its dispatch
@@ -10,6 +10,7 @@ from __future__ import annotations
 import logging
 from typing import Protocol, TYPE_CHECKING
 
+from .agent_decision import AgentDecision
 from .agent_result import AgentResult
 from .agent_run import AgentRun
 
@@ -39,7 +40,115 @@ class TurnDriver(Protocol):
     ) -> AgentResult | None: ...
 
 
-class StandardTurnDriver:
+class BaseTurnDriver:
+    """Shared helpers for all TurnDriver implementations."""
+
+    @staticmethod
+    def _make_result(decision: AgentDecision, run: AgentRun) -> AgentResult:
+        """Canonical AgentResult builder for final_message decisions."""
+        return AgentResult(
+            status="completed",
+            message=decision.message,
+            response=decision.response,
+            decision=decision,
+            prompt=run.rendered_prompt,
+        )
+
+    @staticmethod
+    def _emit_safety_cap_callback(
+        *,
+        agent: "Agent",
+        host: "AgentHostProtocol",
+        run: AgentRun,
+        caller_id: str | None,
+        cap: str,
+        detail: str,
+    ) -> AgentResult | None:
+        """Terminate execution due to a safety-cap violation.
+
+        Escalates via a synthetic callback when there is a parent caller;
+        returns a failed AgentResult directly for top-level runs.
+        """
+        from agent_framework.planning.turn_driver import _inject_cap_reminder
+
+        message = (
+            f"Planning safety cap exceeded: {detail}. "
+            "The plan execution has been halted. Please review the plan configuration."
+        )
+        _inject_cap_reminder(run, cap=cap, detail=detail)
+
+        has_real_caller = caller_id is not None and caller_id != "host"
+        if has_real_caller:
+            synthetic = AgentDecision(
+                kind="callback_to_caller",
+                callback_intent="execution_recovery",
+                message=message,
+                parameters={"cap": cap, "detail": detail},
+            )
+            return agent.handle_callback(
+                host=host, run=run, decision=synthetic, caller_id=caller_id
+            )
+
+        _LOGGER.error(
+            "Safety cap %r triggered for agent %s — terminating run. %s",
+            cap, agent.agent_id, detail,
+        )
+        return AgentResult(
+            status="failed",
+            message=message,
+            prompt=run.rendered_prompt,
+        )
+
+    def _try_decide(
+        self,
+        agent: "Agent",
+        host: "AgentHostProtocol",
+        run: AgentRun,
+        caller_id: str | None,
+        *,
+        planning_active: bool = False,
+    ) -> AgentDecision | AgentResult | None:
+        """Call agent.decide and handle ValueError with run-scoped retry counting.
+
+        Returns:
+        - AgentDecision on success (resets the failure counter).
+        - None on first validation failure (injects error reminder; caller returns None).
+        - AgentResult or None from _emit_safety_cap_callback on second consecutive failure.
+        """
+        context = agent.build_context(host=host, run=run)
+        try:
+            decision = agent.decide(host=host, run=run, context=context, planning_active=planning_active)
+            run.consecutive_validation_failures = 0
+            return decision
+        except ValueError as exc:
+            run.consecutive_validation_failures += 1
+            _LOGGER.error(
+                "Plan validation error for agent %s (consecutive=%d): %s",
+                agent.agent_id, run.consecutive_validation_failures, exc,
+                exc_info=True,
+            )
+            if run.consecutive_validation_failures >= 2:
+                run.consecutive_validation_failures = 0
+                return self._emit_safety_cap_callback(
+                    agent=agent,
+                    host=host,
+                    run=run,
+                    caller_id=caller_id,
+                    cap="consecutive_validation_failures",
+                    detail=f"Two consecutive plan validation errors: {exc}",
+                )
+            error_reminder = (
+                f"<system_reminder>\n"
+                f"<plan_validation_error>{exc}</plan_validation_error>\n"
+                f"The plan you submitted was invalid. Please submit a corrected plan.\n"
+                f"</system_reminder>"
+            )
+            run.conversation_messages.append({"role": "user", "content": error_reminder})
+            run.prompt_fragments.append(error_reminder)
+            return None
+
+
+class StandardTurnDriver(BaseTurnDriver):
     """Faithful extraction of the existing per-turn loop body.
 
     Behavior is identical to the inline loop in Agent.run prior to this
@@ -66,4 +175,4 @@ class StandardTurnDriver:
         return outcome
 
 
-__all__ = ["TurnDriver", "StandardTurnDriver"]
+__all__ = ["TurnDriver", "BaseTurnDriver", "StandardTurnDriver"]

--- a/src/agent_framework/audit_trace.py
+++ b/src/agent_framework/audit_trace.py
@@ -189,6 +189,7 @@ class InMemoryAuditTracer:
             agent_decision={
                 "kind": decision.kind,
                 "message": decision.message,
+                "response": decision.response,
                 "parameters": dict(decision.parameters),
                 "subagent_id": decision.subagent_id,
                 "tool_name": decision.tool_name,

--- a/src/agent_framework/host.py
+++ b/src/agent_framework/host.py
@@ -98,8 +98,7 @@ class SubagentBatchItemResult:
     run_id: str
     status: str  # "completed" | "failed" | "timed_out" | "blocked"
     message: str = ""
-    parameters: dict[str, Any] | None = None
-    parameters_injection: str = "override"
+    response: dict[str, Any] | None = None
     callback_intent: str | None = None
     callback_prompt: str | None = None
 
@@ -1963,19 +1962,23 @@ class AgentHost:
         result: AgentResult,
     ) -> SubagentBatchItemResult:
         if result.status == "blocked":
-            try:
-                import json as _json
-                payload = _json.loads(result.message) if result.message else {}
-            except Exception:
-                payload = {}
+            # Callback metadata is carried in result.response for the new contract;
+            # fall back to parsing result.message as JSON for agents not yet updated.
+            blocked_payload: dict[str, Any] = result.response or {}
+            if not blocked_payload and result.message:
+                try:
+                    import json as _json
+                    blocked_payload = _json.loads(result.message)
+                except Exception:
+                    blocked_payload = {}
             return SubagentBatchItemResult(
                 output_key=spec.output_key,
                 subagent_id=spec.subagent_id,
                 run_id=child_run_id,
                 status="blocked",
                 message=result.message,
-                callback_intent=payload.get("intent"),
-                callback_prompt=payload.get("prompt", ""),
+                callback_intent=blocked_payload.get("intent"),
+                callback_prompt=blocked_payload.get("prompt", ""),
             )
         return SubagentBatchItemResult(
             output_key=spec.output_key,
@@ -1983,8 +1986,7 @@ class AgentHost:
             run_id=child_run_id,
             status=result.status,
             message=result.message,
-            parameters=result.parameters,
-            parameters_injection=result.parameters_injection,
+            response=result.response,
         )
 
     def execute_tool(self, tool_name: str, parameters: dict[str, Any]) -> str:

--- a/src/agent_framework/planning/plan_state.py
+++ b/src/agent_framework/planning/plan_state.py
@@ -110,4 +110,19 @@ class PlanState:
     consecutive_validation_failures: int = 0
 
 
-__all__ = ["PlanStep", "CompletedStep", "PlanState"]
+def plan_step_to_dict(step: PlanStep) -> dict[str, Any]:
+    """Serialize a PlanStep to a plain dict suitable for trace event payloads."""
+    return {
+        "id": step.id,
+        "kind": step.kind,
+        "tool_name": step.tool_name,
+        "subagent_id": step.subagent_id,
+        "skill_name": step.skill_name,
+        "callback_intent": step.callback_intent,
+        "depends_on": list(step.depends_on),
+        "message": step.message,
+        "parameters": dict(step.parameters),
+    }
+
+
+__all__ = ["PlanStep", "CompletedStep", "PlanState", "plan_step_to_dict"]

--- a/src/agent_framework/planning/plan_state.py
+++ b/src/agent_framework/planning/plan_state.py
@@ -107,7 +107,6 @@ class PlanState:
     total_steps_executed: int = 0
     pending_callback_step_id: str | None = None
     awaiting_caller_callback: bool = False
-    consecutive_validation_failures: int = 0
 
 
 def plan_step_to_dict(step: PlanStep) -> dict[str, Any]:

--- a/src/agent_framework/planning/turn_driver.py
+++ b/src/agent_framework/planning/turn_driver.py
@@ -17,7 +17,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed, wait as _future
 from typing import TYPE_CHECKING, Any
 
 from agent_framework.agents.agent_decision import AgentDecision
-from agent_framework.planning.plan_state import CompletedStep, PlanState, PlanStep
+from agent_framework.planning.plan_state import CompletedStep, PlanState, PlanStep, plan_step_to_dict
 from agent_framework.planning.step_reference import resolve as _default_resolve
 
 if TYPE_CHECKING:
@@ -135,6 +135,34 @@ def _inject_cap_reminder(run: "AgentRun", *, cap: str, detail: str) -> None:
     )
     run.conversation_messages.append({"role": "user", "content": reminder})
     run.prompt_fragments.append(reminder)
+
+
+def _emit_plan_updated(
+    run: "AgentRun",
+    agent: "Agent",
+    *,
+    is_initial: bool,
+    previous_plan: "tuple[PlanStep, ...] | None",
+) -> None:
+    """Emit a plan_updated named event after PlanState.plan has been mutated."""
+    from agent_framework.agent_event_publisher import agent_events
+
+    plan_state = run.plan_state
+    new_ids = {s.id for s in plan_state.plan}
+    prev_ids = {s.id for s in previous_plan} if previous_plan else set()
+    agent_events.audit_named_event(
+        run_id=run.run_id,
+        agent_id=agent.agent_id,
+        event={
+            "type": "plan_updated",
+            "is_initial": is_initial,
+            "plan_revision": plan_state.plan_revision,
+            "step_count": len(plan_state.plan),
+            "added_step_ids": sorted(new_ids - prev_ids),
+            "dropped_step_ids": sorted(prev_ids - new_ids),
+            "plan": [plan_step_to_dict(s) for s in plan_state.plan],
+        },
+    )
 
 
 def _dispatch_step(
@@ -377,6 +405,7 @@ class PlanningTurnDriver:
                 "Planning: plan submitted for agent %s — %d steps",
                 agent.agent_id, len(decision.plan),
             )
+            _emit_plan_updated(run, agent, is_initial=True, previous_plan=None)
             _inject_reminder(run, plan_state, end_of_plan=False)
             return None
 
@@ -586,6 +615,7 @@ class PlanningTurnDriver:
                 detail=f"max_plan_revisions={max_revisions} exceeded",
             )
 
+        previous_plan = plan_state.plan
         new_step_ids = {s.id for s in decision.plan}
         for dropped_id in list(plan_state.step_results):
             if dropped_id not in new_step_ids:
@@ -602,6 +632,7 @@ class PlanningTurnDriver:
             "Planning: agent %s re-planned (revision %d) — %d steps",
             agent.agent_id, plan_state.plan_revision, len(decision.plan),
         )
+        _emit_plan_updated(run, agent, is_initial=False, previous_plan=previous_plan)
         _inject_reminder(run, plan_state, end_of_plan=False)
         return None
 

--- a/src/agent_framework/planning/turn_driver.py
+++ b/src/agent_framework/planning/turn_driver.py
@@ -16,6 +16,7 @@ import time
 from concurrent.futures import ThreadPoolExecutor, as_completed, wait as _futures_wait
 from typing import TYPE_CHECKING, Any
 
+from agent_framework.agents.agent import _subagent_result_payload
 from agent_framework.agents.agent_decision import AgentDecision
 from agent_framework.planning.plan_state import CompletedStep, PlanState, PlanStep, plan_step_to_dict
 from agent_framework.planning.step_reference import resolve as _default_resolve
@@ -197,7 +198,11 @@ def _dispatch_step(
                 parameters=params,
                 parent_run_id=run.run_id,
             )
-            result = agent_result.message
+            result = _subagent_result_payload(
+                agent_result.message,
+                agent_result.parameters,
+                agent_result.parameters_injection,
+            )
 
         elif step.kind == "invoke_skill":
             # Delegate to the agent's skill invocation handler.

--- a/src/agent_framework/planning/turn_driver.py
+++ b/src/agent_framework/planning/turn_driver.py
@@ -16,7 +16,6 @@ import time
 from concurrent.futures import ThreadPoolExecutor, as_completed, wait as _futures_wait
 from typing import TYPE_CHECKING, Any
 
-from agent_framework.agents.agent import _subagent_result_payload
 from agent_framework.agents.agent_decision import AgentDecision
 from agent_framework.planning.plan_state import CompletedStep, PlanState, PlanStep, plan_step_to_dict
 from agent_framework.planning.step_reference import resolve as _default_resolve
@@ -692,7 +691,6 @@ class PlanningTurnDriver:
             status="completed",
             message=decision.message,
             response=decision.response,
-            parameters=decision.parameters if decision.parameters else None,
             decision=decision,
             prompt=run.rendered_prompt,
         )

--- a/src/agent_framework/planning/turn_driver.py
+++ b/src/agent_framework/planning/turn_driver.py
@@ -17,6 +17,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed, wait as _future
 from typing import TYPE_CHECKING, Any
 
 from agent_framework.agents.agent_decision import AgentDecision
+from agent_framework.agents.turn_driver import BaseTurnDriver
 from agent_framework.planning.plan_state import CompletedStep, PlanState, PlanStep, plan_step_to_dict
 from agent_framework.planning.step_reference import resolve as _default_resolve
 
@@ -310,7 +311,7 @@ def _dispatch_parallel_batch(
                 )
 
 
-class PlanningTurnDriver:
+class PlanningTurnDriver(BaseTurnDriver):
     """TurnDriver for planning-enabled agents.
 
     Drives the plan → execute → reflect lifecycle. Each run_turn call
@@ -319,9 +320,6 @@ class PlanningTurnDriver:
 
     def __init__(self, config: "PlanningConfig") -> None:
         self.config = config
-        # Tracks consecutive plan-phase validation failures per run_id.
-        # Used because plan_state doesn't exist until the first valid submit_plan.
-        self._plan_phase_failures: dict[str, int] = {}
 
     def run_turn(
         self,
@@ -363,40 +361,10 @@ class PlanningTurnDriver:
         """No plan yet — call model, expect submit_plan."""
         _LOGGER.debug("Planning: entering PLAN phase for agent %s", agent.agent_id)
 
-        context = agent.build_context(host=host, run=run)
-        try:
-            decision = agent.decide(host=host, run=run, context=context, planning_active=True)
-        except ValueError as exc:
-            run_id = run.run_id
-            failures = self._plan_phase_failures.get(run_id, 0) + 1
-            self._plan_phase_failures[run_id] = failures
-            _LOGGER.error(
-                "Planning: plan validation error for agent %s (consecutive=%d): %s",
-                agent.agent_id, failures, exc,
-                exc_info=True,
-            )
-            if failures >= 2:
-                self._plan_phase_failures.pop(run_id, None)
-                return self._emit_safety_cap_callback(
-                    agent=agent,
-                    host=host,
-                    run=run,
-                    caller_id=caller_id,
-                    cap="consecutive_validation_failures",
-                    detail=f"Two consecutive plan validation errors: {exc}",
-                )
-            error_reminder = (
-                f"<system_reminder>\n"
-                f"<plan_validation_error>{exc}</plan_validation_error>\n"
-                f"The plan you submitted was invalid. Please submit a corrected plan.\n"
-                f"</system_reminder>"
-            )
-            run.conversation_messages.append({"role": "user", "content": error_reminder})
-            run.prompt_fragments.append(error_reminder)
-            return None
-
-        # Clear per-run failure counter on successful model call.
-        self._plan_phase_failures.pop(run.run_id, None)
+        result = self._try_decide(agent, host, run, caller_id, planning_active=True)
+        if not isinstance(result, AgentDecision):
+            return result
+        decision = result
 
         if decision.kind == "submit_plan":
             # decision.plan is already validated by from_model_response — no extra validation needed.
@@ -503,36 +471,10 @@ class PlanningTurnDriver:
 
         _inject_reminder(run, plan_state, end_of_plan=end_of_plan)
 
-        context = agent.build_context(host=host, run=run)
-        try:
-            decision = agent.decide(host=host, run=run, context=context, planning_active=True)
-        except ValueError as exc:
-            # Plan validation failed (invalid submit_plan from the model).
-            plan_state.consecutive_validation_failures += 1
-            _LOGGER.error(
-                "Planning: plan validation error for agent %s (consecutive=%d): %s",
-                agent.agent_id, plan_state.consecutive_validation_failures, exc,
-                exc_info=True,
-            )
-            if plan_state.consecutive_validation_failures >= 2:
-                return self._emit_safety_cap_callback(
-                    agent=agent,
-                    host=host,
-                    run=run,
-                    caller_id=caller_id,
-                    cap="consecutive_validation_failures",
-                    detail=f"Two consecutive plan validation errors: {exc}",
-                )
-            # First failure: inject error reminder and let model retry next reflect.
-            error_reminder = (
-                f"<system_reminder>\n"
-                f"<plan_validation_error>{exc}</plan_validation_error>\n"
-                f"The plan you submitted was invalid. Please submit a corrected plan.\n"
-                f"</system_reminder>"
-            )
-            run.conversation_messages.append({"role": "user", "content": error_reminder})
-            run.prompt_fragments.append(error_reminder)
-            return None
+        result = self._try_decide(agent, host, run, caller_id, planning_active=True)
+        if not isinstance(result, AgentDecision):
+            return result
+        decision = result
 
         if decision.kind == "final_message":
             return self._make_result(decision, run)
@@ -628,7 +570,7 @@ class PlanningTurnDriver:
         plan_state.plan = decision.plan
         plan_state.plan_revision += 1
         plan_state.pending_callback_step_id = None
-        plan_state.consecutive_validation_failures = 0
+        run.consecutive_validation_failures = 0
         _LOGGER.info(
             "Planning: agent %s re-planned (revision %d) — %d steps",
             agent.agent_id, plan_state.plan_revision, len(decision.plan),
@@ -636,64 +578,6 @@ class PlanningTurnDriver:
         _emit_plan_updated(run, agent, is_initial=False, previous_plan=previous_plan)
         _inject_reminder(run, plan_state, end_of_plan=False)
         return None
-
-    def _emit_safety_cap_callback(
-        self,
-        *,
-        agent: "Agent",
-        host: Any,
-        run: "AgentRun",
-        caller_id: str | None,
-        cap: str,
-        detail: str,
-    ) -> "AgentResult | None":
-        """Terminate execution due to a safety-cap violation.
-
-        When there is a parent caller, escalate via a synthetic callback so the
-        caller can handle the failure. When there is no caller (top-level run),
-        return a failed AgentResult directly — calling handle_callback in that
-        case would block waiting for user input.
-        """
-        from agent_framework.agents.agent_result import AgentResult
-
-        message = (
-            f"Planning safety cap exceeded: {detail}. "
-            "The plan execution has been halted. Please review the plan configuration."
-        )
-        _inject_cap_reminder(run, cap=cap, detail=detail)
-
-        has_real_caller = caller_id is not None and caller_id != "host"
-        if has_real_caller:
-            synthetic = AgentDecision(
-                kind="callback_to_caller",
-                callback_intent="execution_recovery",
-                message=message,
-                parameters={"cap": cap, "detail": detail},
-            )
-            return agent.handle_callback(
-                host=host, run=run, decision=synthetic, caller_id=caller_id
-            )
-
-        _LOGGER.error(
-            "Planning: safety cap %r triggered for agent %s — terminating run. %s",
-            cap, agent.agent_id, detail,
-        )
-        return AgentResult(
-            status="failed",
-            message=message,
-            prompt=run.rendered_prompt,
-        )
-
-    @staticmethod
-    def _make_result(decision: AgentDecision, run: "AgentRun") -> "AgentResult":
-        from agent_framework.agents.agent_result import AgentResult
-        return AgentResult(
-            status="completed",
-            message=decision.message,
-            response=decision.response,
-            decision=decision,
-            prompt=run.rendered_prompt,
-        )
 
 
 __all__ = ["PlanningTurnDriver"]

--- a/src/agent_framework/planning/turn_driver.py
+++ b/src/agent_framework/planning/turn_driver.py
@@ -689,6 +689,7 @@ class PlanningTurnDriver:
         return AgentResult(
             status="completed",
             message=decision.message,
+            parameters=decision.parameters if decision.parameters else None,
             decision=decision,
             prompt=run.rendered_prompt,
         )

--- a/src/agent_framework/planning/turn_driver.py
+++ b/src/agent_framework/planning/turn_driver.py
@@ -192,17 +192,14 @@ def _dispatch_step(
             result = host.execute_tool(step.tool_name, params)
 
         elif step.kind == "call_subagent":
+            from agent_framework.agents.agent import _render_result_for_injection
             agent_result = host.call_subagent(
                 caller=agent,
                 callee_id=step.subagent_id,
                 parameters=params,
                 parent_run_id=run.run_id,
             )
-            result = _subagent_result_payload(
-                agent_result.message,
-                agent_result.parameters,
-                agent_result.parameters_injection,
-            )
+            result = _render_result_for_injection(agent_result)
 
         elif step.kind == "invoke_skill":
             # Delegate to the agent's skill invocation handler.
@@ -694,6 +691,7 @@ class PlanningTurnDriver:
         return AgentResult(
             status="completed",
             message=decision.message,
+            response=decision.response,
             parameters=decision.parameters if decision.parameters else None,
             decision=decision,
             prompt=run.rendered_prompt,

--- a/src/agent_framework/runtime_trace_behavior.py
+++ b/src/agent_framework/runtime_trace_behavior.py
@@ -302,7 +302,7 @@ class RuntimeTraceBehavior(AgentBehavior):
             return None
         inv = event.invocation
         try:
-            decision = AgentDecision.from_model_response(event.response)
+            decision = AgentDecision.from_model_response(event.response, planning_active=True)
             payload = _decision_payload(decision)
         except Exception:
             payload = {"error": "could_not_parse_decision", "raw": event.response.content if hasattr(event.response, "content") else None}

--- a/src/agent_framework/runtime_trace_behavior.py
+++ b/src/agent_framework/runtime_trace_behavior.py
@@ -125,6 +125,7 @@ class RuntimeTraceBehavior(AgentBehavior):
                     "status": result.status,
                     "caller_id": caller_id,
                     "message": result.message or None,
+                    "response": result.response or None,
                     "parameters": result.parameters or None,
                     "usage_self": usage_summary.get("usage_self", {}),
                     "usage_inclusive": usage_summary.get("usage_inclusive", {}),
@@ -217,6 +218,7 @@ class RuntimeTraceBehavior(AgentBehavior):
                 "subagent_id": event.subagent_id,
                 "status": event.result.status,
                 "message": event.result.message or None,
+                "response": event.result.response or None,
                 "parameters": event.result.parameters or None,
             },
             context=_merge_context(

--- a/src/agent_framework/runtime_trace_behavior.py
+++ b/src/agent_framework/runtime_trace_behavior.py
@@ -126,7 +126,6 @@ class RuntimeTraceBehavior(AgentBehavior):
                     "caller_id": caller_id,
                     "message": result.message or None,
                     "response": result.response or None,
-                    "parameters": result.parameters or None,
                     "usage_self": usage_summary.get("usage_self", {}),
                     "usage_inclusive": usage_summary.get("usage_inclusive", {}),
                 },
@@ -219,7 +218,6 @@ class RuntimeTraceBehavior(AgentBehavior):
                 "status": event.result.status,
                 "message": event.result.message or None,
                 "response": event.result.response or None,
-                "parameters": event.result.parameters or None,
             },
             context=_merge_context(
                 h,

--- a/src/agent_framework_evaluator/evaluation.py
+++ b/src/agent_framework_evaluator/evaluation.py
@@ -271,19 +271,15 @@ def select_agent_result_field(agent_result: Any, field_name: Any) -> str | None:
         value = _traverse_dict(agent_result, parts)
         if value is not _MISSING:
             return _stringify_result_value(value)
-        # For sub-paths like "status" that may live under "response" in the new
-        # contract, try "response.<path>" before falling back to "parameters.<path>".
+        # For bare sub-paths (e.g. "status", "count") try "response.<path>" first,
+        # then "parameters.<path>" (decision call inputs still live there).
         if len(parts) >= 1 and parts[0] not in ("response", "parameters", "message", "status"):
-            response_dict = agent_result.get("response")
-            if isinstance(response_dict, dict):
-                value = _traverse_dict(response_dict, parts)
-                if value is not _MISSING:
-                    return _stringify_result_value(value)
-            params_dict = agent_result.get("parameters")
-            if isinstance(params_dict, dict):
-                value = _traverse_dict(params_dict, parts)
-                if value is not _MISSING:
-                    return _stringify_result_value(value)
+            for container_key in ("response", "parameters"):
+                container = agent_result.get(container_key)
+                if isinstance(container, dict):
+                    value = _traverse_dict(container, parts)
+                    if value is not _MISSING:
+                        return _stringify_result_value(value)
         return None
     return _stringify_result_value(agent_result)
 

--- a/src/agent_framework_evaluator/evaluation.py
+++ b/src/agent_framework_evaluator/evaluation.py
@@ -235,12 +235,30 @@ def _stringify_result_value(value: Any) -> str:
         return str(value)
 
 
+def _traverse_dict(d: dict, parts: list[str]) -> Any:
+    current: Any = d
+    for part in parts:
+        if not part:
+            continue
+        if isinstance(current, dict) and part in current:
+            current = current[part]
+        else:
+            return _MISSING
+    return current
+
+
+_MISSING = object()
+
+
 def select_agent_result_field(agent_result: Any, field_name: Any) -> str | None:
     """Select *field_name* (dot-delimited path) from *agent_result*.
 
     Returns ``None`` when the path does not exist in the result dict, so callers
     can distinguish a missing field from an empty value and raise an appropriate
     error.  Returns the full stringified payload when *field_name* is ``"."``.
+
+    For structured paths (e.g. ``response.status``), ``response`` is checked
+    before ``parameters`` so that the new typed channel takes precedence.
     """
     field = str(field_name or "message").strip() or "message"
     if field == ".":
@@ -248,15 +266,25 @@ def select_agent_result_field(agent_result: Any, field_name: Any) -> str | None:
     if isinstance(agent_result, str):
         return agent_result
     if isinstance(agent_result, dict):
-        current: Any = agent_result
-        for part in field.split("."):
-            if not part:
-                continue
-            if isinstance(current, dict) and part in current:
-                current = current[part]
-            else:
-                return None
-        return _stringify_result_value(current)
+        parts = [p for p in field.split(".") if p]
+        # Try the path directly first (handles "message", "response", "response.x", …).
+        value = _traverse_dict(agent_result, parts)
+        if value is not _MISSING:
+            return _stringify_result_value(value)
+        # For sub-paths like "status" that may live under "response" in the new
+        # contract, try "response.<path>" before falling back to "parameters.<path>".
+        if len(parts) >= 1 and parts[0] not in ("response", "parameters", "message", "status"):
+            response_dict = agent_result.get("response")
+            if isinstance(response_dict, dict):
+                value = _traverse_dict(response_dict, parts)
+                if value is not _MISSING:
+                    return _stringify_result_value(value)
+            params_dict = agent_result.get("parameters")
+            if isinstance(params_dict, dict):
+                value = _traverse_dict(params_dict, parts)
+                if value is not _MISSING:
+                    return _stringify_result_value(value)
+        return None
     return _stringify_result_value(agent_result)
 
 

--- a/src/agent_framework_evaluator/runtime/session_runner.py
+++ b/src/agent_framework_evaluator/runtime/session_runner.py
@@ -35,9 +35,14 @@ def _agent_result_payload(result: AgentResult) -> dict[str, object]:
         "status": result.status,
         "message": result.message,
     }
+    if result.response is not None:
+        payload["response"] = result.response
     if result.decision is not None:
         payload["kind"] = result.decision.kind
-        payload["parameters"] = dict(result.decision.parameters)
+        # decision.parameters holds the call inputs that produced this result; expose
+        # them at the top level for evaluator dot-path access (e.g. "status", "count").
+        if result.decision.parameters:
+            payload["parameters"] = dict(result.decision.parameters)
         if result.decision.subagent_id is not None:
             payload["subagent_id"] = result.decision.subagent_id
         if result.decision.tool_name is not None:

--- a/src/agent_framework_evaluator/web/app.js
+++ b/src/agent_framework_evaluator/web/app.js
@@ -1086,7 +1086,7 @@ async function runAllCasesPlay() {
   }
 }
 
-function renderStringInTrace(parent, s, keyHint) {
+function renderStringInTrace(parent, s, keyHint, siblingResponse) {
   const wrap = document.createElement("span");
   wrap.className = "trace-json-str";
   const openQ = document.createElement("span");
@@ -1102,10 +1102,13 @@ function renderStringInTrace(parent, s, keyHint) {
     inner.setAttribute("role", "button");
     inner.tabIndex = 0;
     inner.title = `Open full text (${s.length} characters)`;
+    const opts = siblingResponse !== undefined
+      ? { message: s, response: siblingResponse }
+      : undefined;
     const open = (e) => {
       e.preventDefault();
       e.stopPropagation();
-      openTraceDetailModal(String(keyHint || "Field"), s);
+      openTraceDetailModal(String(keyHint || "Field"), s, opts);
     };
     inner.addEventListener("click", open);
     inner.addEventListener("keydown", (e) => {
@@ -1125,7 +1128,7 @@ function renderStringInTrace(parent, s, keyHint) {
   parent.appendChild(wrap);
 }
 
-function appendJsonValue(parent, value, keyHint) {
+function appendJsonValue(parent, value, keyHint, siblingResponse) {
   if (value === null) {
     const span = document.createElement("span");
     span.className = "trace-json-lit trace-json-null";
@@ -1135,7 +1138,7 @@ function appendJsonValue(parent, value, keyHint) {
   }
   const t = typeof value;
   if (t === "string") {
-    renderStringInTrace(parent, value, keyHint);
+    renderStringInTrace(parent, value, keyHint, siblingResponse);
     return;
   }
   if (t === "number" || t === "boolean") {
@@ -1180,14 +1183,20 @@ function appendJsonValue(parent, value, keyHint) {
     }
     const obj = document.createElement("div");
     obj.className = "trace-json-obj";
+    // When an object has a "message" string and a "response" field, pass response
+    // as context so the long-message popup shows both Message and Response tabs.
+    const msgResponseCtx = (typeof value.message === "string" && "response" in value)
+      ? value.response
+      : undefined;
     for (const k of keys) {
-      obj.appendChild(renderJsonKeyRow(k, value[k], keyHint ? `${keyHint}.${k}` : k));
+      const ctx = (k === "message" && msgResponseCtx !== undefined) ? msgResponseCtx : undefined;
+      obj.appendChild(renderJsonKeyRow(k, value[k], keyHint ? `${keyHint}.${k}` : k, ctx));
     }
     parent.appendChild(obj);
   }
 }
 
-function renderJsonKeyRow(k, v, path) {
+function renderJsonKeyRow(k, v, path, siblingResponse) {
   const row = document.createElement("div");
   row.className = "trace-json-kv";
   const keyEl = document.createElement("span");
@@ -1196,7 +1205,7 @@ function renderJsonKeyRow(k, v, path) {
   row.appendChild(keyEl);
   const valWrap = document.createElement("span");
   valWrap.className = "trace-json-val";
-  appendJsonValue(valWrap, v, path);
+  appendJsonValue(valWrap, v, path, siblingResponse);
   row.appendChild(valWrap);
   return row;
 }

--- a/src/agent_framework_evaluator/web/app.js
+++ b/src/agent_framework_evaluator/web/app.js
@@ -1586,6 +1586,7 @@ function classifyEventKind(kind) {
   if (kind.includes("decision")) return { icon: "◎", cssClass: "trace-event--decision" };
   if (kind.includes("model_call")) return { icon: "⊡", cssClass: "trace-event--model" };
   if (kind.includes("context_updated")) return { icon: "≡", cssClass: "trace-event--context" };
+  if (kind.includes("plan_updated")) return { icon: "📋", cssClass: "trace-event--plan" };
   return null;
 }
 
@@ -1954,6 +1955,78 @@ function appendTraceEventRow(event) {
   traceFeed.scrollTop = traceFeed.scrollHeight;
 }
 
+/** Groups flat plan steps into ordered ready-batches using depends_on DAG. */
+function groupPlanIntoBatches(plan) {
+  if (!Array.isArray(plan) || plan.length === 0) return [];
+  const batches = [];
+  const emitted = new Set();
+  while (emitted.size < plan.length) {
+    const batch = plan.filter(s => {
+      if (emitted.has(s.id)) return false;
+      const deps = Array.isArray(s.depends_on) ? s.depends_on : [];
+      return deps.every(d => emitted.has(d));
+    });
+    if (batch.length === 0) break; // cycle guard
+    for (const s of batch) emitted.add(s.id);
+    batches.push(batch);
+  }
+  return batches;
+}
+
+/** Renders plan steps grouped into parallel/sequential batches. */
+function buildPlanBatchesElement(plan) {
+  const container = document.createElement("div");
+  container.className = "flow-plan-batches";
+  const batches = groupPlanIntoBatches(plan);
+  batches.forEach((batch, i) => {
+    const batchEl = document.createElement("div");
+    batchEl.className = "flow-plan-batch";
+    const mode = batch.length > 1 ? "parallel" : "sequential";
+    const label = document.createElement("span");
+    label.className = "flow-plan-batch-label";
+    label.textContent = `${mode === "parallel" ? "⊕" : "→"} batch ${i + 1} (${mode})`;
+    batchEl.appendChild(label);
+    const stepsEl = document.createElement("div");
+    stepsEl.className = `flow-plan-batch-steps flow-plan-batch-steps--${mode}`;
+    for (const step of batch) {
+      const stepEl = document.createElement("div");
+      stepEl.className = "flow-plan-step";
+      const kind = step.kind || "";
+      const name = step.tool_name || step.subagent_id || step.skill_name || step.callback_intent || "";
+      stepEl.textContent = `↳ ${step.id}  (${kind}${name ? ": " + name : ""})`;
+      stepsEl.appendChild(stepEl);
+    }
+    batchEl.appendChild(stepsEl);
+    container.appendChild(batchEl);
+  });
+  return container;
+}
+
+/** Builds a custom trace-pane row for a plan_updated event. */
+function buildPlanUpdatedTraceRow(event, planEvent) {
+  const node = document.createElement("details");
+  node.className = "trace-event-row trace-feed-row trace-event--plan";
+  node.dataset.channel = typeof event.channel === "string" ? event.channel : "runtime";
+  node.dataset.level = "info";
+  const rev = planEvent.plan_revision || 1;
+  const count = planEvent.step_count || 0;
+  const added = Array.isArray(planEvent.added_step_ids) ? planEvent.added_step_ids.length : 0;
+  const dropped = Array.isArray(planEvent.dropped_step_ids) ? planEvent.dropped_step_ids.length : 0;
+  const diffStr = planEvent.is_initial ? "" : ` (+${added} / -${dropped})`;
+  const summary = document.createElement("summary");
+  summary.textContent = `📋 plan updated: revision ${rev} — ${count} steps${diffStr}`;
+  const body = document.createElement("div");
+  body.className = "trace-event-body";
+  const plan = Array.isArray(planEvent.plan) ? planEvent.plan : [];
+  if (plan.length > 0) {
+    body.appendChild(buildPlanBatchesElement(plan));
+  }
+  body.appendChild(renderPayloadTree(event.payload || {}));
+  node.appendChild(summary);
+  node.appendChild(body);
+  return node;
+}
+
 function buildFlowNode(runId, depth) {
   const fr = runFrames.get(runId);
   if (!fr) return null;
@@ -1980,6 +2053,27 @@ function buildFlowNode(runId, depth) {
     setTimeout(() => fr.details.classList.remove("flow-highlight"), 1500);
   });
   node.appendChild(pill);
+
+  if (fr.planUpdates && fr.planUpdates.length > 0) {
+    for (const pu of fr.planUpdates) {
+      const puEl = document.createElement("details");
+      puEl.className = "flow-plan-update";
+      puEl.style.marginLeft = `${(depth + 1) * 20}px`;
+      const rev = pu.plan_revision || 1;
+      const count = pu.step_count || 0;
+      const added = Array.isArray(pu.added_step_ids) ? pu.added_step_ids.length : 0;
+      const dropped = Array.isArray(pu.dropped_step_ids) ? pu.dropped_step_ids.length : 0;
+      const diffStr = pu.is_initial ? "" : ` (+${added} / -${dropped})`;
+      const puSummary = document.createElement("summary");
+      puSummary.textContent = `📋 plan updated: v${rev} (${count} steps${diffStr})`;
+      puEl.appendChild(puSummary);
+      const plan = Array.isArray(pu.plan) ? pu.plan : [];
+      if (plan.length > 0) {
+        puEl.appendChild(buildPlanBatchesElement(plan));
+      }
+      node.appendChild(puEl);
+    }
+  }
 
   const childrenWithBatch = [];
   for (const [bid, bf] of batchFrames) {
@@ -2082,6 +2176,23 @@ function routeTraceEvent(event) {
     }
     if (eventType === "subagent_batch_finished") {
       endBatchFrame(event);
+      return;
+    }
+    if (eventType === "plan_updated") {
+      const rid = getEventRunId(event);
+      const node = buildPlanUpdatedTraceRow(event, batchEvent);
+      const container = resolveRunContainer(rid);
+      container.appendChild(node);
+      const entry = { el: node, event };
+      unifiedEntries.push(entry);
+      setEntryVisible(entry);
+      traceFeed.scrollTop = traceFeed.scrollHeight;
+      if (rid && runFrames.has(rid)) {
+        const fr = runFrames.get(rid);
+        if (!fr.planUpdates) fr.planUpdates = [];
+        fr.planUpdates.push(batchEvent);
+        rebuildFlowTab();
+      }
       return;
     }
   }

--- a/src/agent_framework_evaluator/web/index.html
+++ b/src/agent_framework_evaluator/web/index.html
@@ -205,10 +205,14 @@
       <div class="trace-detail-dialog-tabs" id="trace-detail-dialog-tabs" hidden>
         <button type="button" class="trace-detail-tab trace-detail-tab--active" data-panel="source" id="trace-detail-tab-source">Source</button>
         <button type="button" class="trace-detail-tab" data-panel="md" id="trace-detail-tab-md">Markdown</button>
+        <button type="button" class="trace-detail-tab" data-panel="message" id="trace-detail-tab-message" hidden>Message</button>
+        <button type="button" class="trace-detail-tab" data-panel="response" id="trace-detail-tab-response" hidden>Response</button>
       </div>
       <div class="trace-detail-dialog-body">
         <pre id="trace-detail-modal-source" class="trace-detail-panel trace-detail-panel--active trace-detail-dialog-pre"></pre>
         <div id="trace-detail-modal-md" class="trace-detail-panel trace-detail-md-body"></div>
+        <div id="trace-detail-modal-message" class="trace-detail-panel trace-detail-md-body"></div>
+        <pre id="trace-detail-modal-response" class="trace-detail-panel trace-detail-dialog-pre"></pre>
       </div>
     </div>
   </dialog>

--- a/src/agent_framework_evaluator/web/scripts/trace-detail-modal.js
+++ b/src/agent_framework_evaluator/web/scripts/trace-detail-modal.js
@@ -18,57 +18,109 @@
     return null;
   }
 
-  function openTraceDetailModal(title, text) {
+  function renderMdInto(el, text) {
+    el.textContent = "";
+    const parseMd = getMarkedParse();
+    if (parseMd) {
+      try {
+        const html = parseMd(text, { breaks: true });
+        const frag = document.createRange().createContextualFragment(html);
+        el.appendChild(frag);
+      } catch (_) {
+        el.textContent = text;
+      }
+    } else {
+      el.style.whiteSpace = "pre-wrap";
+      el.style.overflowWrap = "anywhere";
+      el.textContent = text;
+    }
+  }
+
+  /**
+   * Open the trace detail modal.
+   * @param {string} title
+   * @param {string} text  Raw string always shown in the Source tab.
+   * @param {object} [opts]
+   * @param {string} [opts.message]  Show a Message tab with markdown rendering.
+   * @param {unknown} [opts.response] Show a Response tab with prettified JSON.
+   */
+  function openTraceDetailModal(title, text, opts) {
     const modal = document.getElementById("trace-detail-modal");
     const titleEl = document.getElementById("trace-detail-modal-title");
     const srcEl = document.getElementById("trace-detail-modal-source");
     const mdEl = document.getElementById("trace-detail-modal-md");
+    const msgEl = document.getElementById("trace-detail-modal-message");
+    const respEl = document.getElementById("trace-detail-modal-response");
     const tabs = document.getElementById("trace-detail-dialog-tabs");
-    const tabSrc = document.getElementById("trace-detail-tab-source");
     const tabMd = document.getElementById("trace-detail-tab-md");
+    const tabMsg = document.getElementById("trace-detail-tab-message");
+    const tabResp = document.getElementById("trace-detail-tab-response");
     if (!modal || !titleEl || !srcEl || !mdEl) return;
+
+    const hasMessage = opts && typeof opts.message === "string";
+    const hasResponse = opts && opts.response != null;
+
     titleEl.textContent = title;
     srcEl.textContent = text;
-    const parseMd = getMarkedParse();
-    const showMd = Boolean(parseMd && looksLikeMarkdown(text));
-    mdEl.innerHTML = "";
-    if (showMd && parseMd) {
-      try {
-        mdEl.innerHTML = parseMd(text);
-      } catch (_) {
-        mdEl.innerHTML = "<p><em>Could not render as Markdown.</em></p>";
+
+    if (msgEl && tabMsg) {
+      if (hasMessage) {
+        renderMdInto(msgEl, opts.message);
+        tabMsg.hidden = false;
+      } else {
+        msgEl.textContent = "";
+        tabMsg.hidden = true;
       }
     }
-    if (tabs) tabs.hidden = !showMd;
+
+    if (respEl && tabResp) {
+      if (hasResponse) {
+        try { respEl.textContent = JSON.stringify(opts.response, null, 2); }
+        catch (_) { respEl.textContent = String(opts.response); }
+        tabResp.hidden = false;
+      } else {
+        respEl.textContent = "";
+        tabResp.hidden = true;
+      }
+    }
+
+    const parseMd = getMarkedParse();
+    const showMd = Boolean(!hasMessage && parseMd && looksLikeMarkdown(text));
+    mdEl.textContent = "";
+    if (showMd && parseMd) {
+      renderMdInto(mdEl, text);
+    }
     if (tabMd) tabMd.style.display = showMd ? "" : "none";
-    if (tabSrc) tabSrc.classList.add("trace-detail-tab--active");
-    if (tabMd) tabMd.classList.remove("trace-detail-tab--active");
-    srcEl.classList.add("trace-detail-panel--active");
-    mdEl.classList.remove("trace-detail-panel--active");
+
+    const anyExtra = hasMessage || hasResponse || showMd;
+    if (tabs) tabs.hidden = !anyExtra;
+
+    _activatePanel(hasMessage ? "message" : "source");
     modal.showModal();
+  }
+
+  function _activatePanel(which) {
+    const panelIds = ["source", "md", "message", "response"];
+    for (const id of panelIds) {
+      const panel = document.getElementById(`trace-detail-modal-${id}`);
+      const btn = document.getElementById(`trace-detail-tab-${id}`);
+      panel?.classList.toggle("trace-detail-panel--active", id === which);
+      btn?.classList.toggle("trace-detail-tab--active", id === which);
+    }
   }
 
   function wireTraceDetailModal() {
     const modal = document.getElementById("trace-detail-modal");
     const closeBtn = document.getElementById("trace-detail-modal-close");
-    const tabSrc = document.getElementById("trace-detail-tab-source");
-    const tabMd = document.getElementById("trace-detail-tab-md");
-    const srcEl = document.getElementById("trace-detail-modal-source");
-    const mdEl = document.getElementById("trace-detail-modal-md");
     if (!modal || !closeBtn) return;
     closeBtn.addEventListener("click", () => modal.close());
     modal.addEventListener("click", (e) => {
       if (e.target === modal) modal.close();
     });
-    function showPanel(which) {
-      const showSrc = which === "source";
-      srcEl?.classList.toggle("trace-detail-panel--active", showSrc);
-      mdEl?.classList.toggle("trace-detail-panel--active", !showSrc);
-      tabSrc?.classList.toggle("trace-detail-tab--active", showSrc);
-      tabMd?.classList.toggle("trace-detail-tab--active", !showSrc);
+    for (const id of ["source", "md", "message", "response"]) {
+      document.getElementById(`trace-detail-tab-${id}`)
+        ?.addEventListener("click", () => _activatePanel(id));
     }
-    tabSrc?.addEventListener("click", () => showPanel("source"));
-    tabMd?.addEventListener("click", () => showPanel("md"));
   }
 
   window.getMarkedParse = getMarkedParse;

--- a/src/agent_framework_evaluator/web/styles.css
+++ b/src/agent_framework_evaluator/web/styles.css
@@ -1506,6 +1506,9 @@ body {
 .trace-event--subagent > summary { border-left-color: #40a0a0; }
 .trace-event--subagent { border-left-color: #40a0a0; }
 
+.trace-event--plan > summary { border-left-color: #c0a060; }
+.trace-event--plan { border-left-color: #c0a060; }
+
 /* ── Batch containers ──────────────────────────────────────── */
 
 .trace-batch {
@@ -1637,6 +1640,65 @@ body {
   display: flex;
   flex-direction: column;
   gap: 0.3rem;
+}
+
+.flow-plan-update {
+  margin-top: 0.2rem;
+  padding: 0.2rem 0.5rem 0.4rem;
+  border: 1px solid rgba(192, 160, 96, 0.4);
+  border-radius: 5px;
+  font-size: 0.8rem;
+  background: rgba(192, 160, 96, 0.07);
+}
+
+.flow-plan-update > summary {
+  cursor: pointer;
+  color: var(--text);
+  font-weight: 500;
+  list-style: none;
+  padding: 0.1rem 0;
+}
+
+.flow-plan-batches {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  margin-top: 0.35rem;
+}
+
+.flow-plan-batch {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  padding: 0.2rem 0.4rem;
+  border: 1px dashed rgba(192, 160, 96, 0.3);
+  border-radius: 4px;
+}
+
+.flow-plan-batch-label {
+  font-size: 0.72rem;
+  font-weight: 600;
+  color: var(--muted);
+  letter-spacing: 0.02em;
+}
+
+.flow-plan-batch-steps--parallel {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.flow-plan-batch-steps--sequential {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+}
+
+.flow-plan-step {
+  font-size: 0.78rem;
+  color: var(--muted);
+  padding: 0.05rem 0.2rem;
+  font-family: var(--mono, monospace);
 }
 
 /* Highlight animation when scrolled-to from flow tab */

--- a/tests/planning/test_planning_turn_driver_safety.py
+++ b/tests/planning/test_planning_turn_driver_safety.py
@@ -312,7 +312,7 @@ def test_plan_validation_error_logged(tmp_path: Path, caplog):
     ])
     _register_echo(host)
 
-    with caplog.at_level(logging.ERROR, logger="agent_framework.planning.turn_driver"):
+    with caplog.at_level(logging.ERROR, logger="agent_framework.agents.turn_driver"):
         host.run_agent("planner", "validate")
 
-    assert any("plan validation error" in r.message for r in caplog.records)
+    assert any("plan validation error" in r.message.lower() for r in caplog.records)

--- a/tests/planning/test_turn_driver_tracing.py
+++ b/tests/planning/test_turn_driver_tracing.py
@@ -1,0 +1,140 @@
+"""Tests that PlanningTurnDriver emits plan_updated named events."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from agent_framework.host import AgentHost
+from agent_framework.model import ModelContext, ModelResponse
+from agent_framework.tracing import CompositeRuntimeTracer, TraceEvent
+
+
+class _TraceRecorder:
+    def __init__(self) -> None:
+        self.events: list[TraceEvent] = []
+
+    def consume(self, event: TraceEvent) -> None:
+        self.events.append(event)
+
+
+class _ScriptedDriver:
+    def __init__(self, payloads: list[dict]) -> None:
+        self._payloads = list(payloads)
+
+    def set_trace_callbacks(self, *, on_request=None, on_response=None) -> None:
+        pass
+
+    def decide(self, *, agent_id, provider_name, model_names, temperature, context: ModelContext):
+        if not self._payloads:
+            raise RuntimeError("Scripted driver exhausted")
+        payload = self._payloads.pop(0)
+        return ModelResponse(payload=payload, raw_text=str(payload))
+
+
+def _make_host(tmp_path: Path, payloads: list[dict], *, agent_id: str = "planner") -> tuple[AgentHost, _TraceRecorder]:
+    agent_path = tmp_path / f"{agent_id}.md"
+    agent_path.write_text(
+        f"---\nid: {agent_id}\nrole: planner\nplanning:\n  enabled: true\n---\nYou are a planner.\n---\nExecute.\n",
+        encoding="utf-8",
+    )
+    env = tmp_path / ".env"
+    env.write_text(
+        "\n".join([
+            "OPENAI_API_KEY=test-key",
+            "DEFAULT_PROVIDER=openai",
+            "DEFAULT_MODEL=gpt-4o-mini",
+            f"AGENT_DIRECTORY={tmp_path}",
+            f"ROOT_AGENT={agent_id}",
+        ]),
+        encoding="utf-8",
+    )
+    host = AgentHost.from_env(env)
+    recorder = _TraceRecorder()
+    host.runtime_tracer = CompositeRuntimeTracer(subscribers=[recorder])
+    host.model_driver = _ScriptedDriver(payloads)
+
+    from agent_framework.tool import Tool, ToolDefinition, ToolParameter
+
+    class EchoTool(Tool):
+        def invoke(self, parameters: dict, host: Any) -> str:
+            return str(parameters.get("msg", ""))
+
+    host.tool_registry.register(
+        EchoTool(definition=ToolDefinition(
+            tool_id="echo",
+            description="Echo msg.",
+            parameters=(ToolParameter("msg", "msg", required=False),),
+        ))
+    )
+    return host, recorder
+
+
+_STEP_A = {"id": "step_a", "kind": "call_tool", "tool_name": "echo", "parameters": {"msg": "a"}}
+_STEP_B = {"id": "step_b", "kind": "call_tool", "tool_name": "echo", "parameters": {"msg": "b"}, "depends_on": ["step_a"]}
+_STEP_C = {"id": "step_c", "kind": "call_tool", "tool_name": "echo", "parameters": {"msg": "c"}}
+
+
+def _named_plan_events(recorder: _TraceRecorder, run_id: str) -> list[dict]:
+    return [
+        e.payload["event"]
+        for e in recorder.events
+        if e.kind == "runtime.audit.named_event"
+        and e.context.run_id == run_id
+        and isinstance(e.payload.get("event"), dict)
+        and e.payload["event"].get("type") == "plan_updated"
+    ]
+
+
+def test_plan_updated_event_emitted_on_initial_submit(tmp_path: Path) -> None:
+    host, recorder = _make_host(tmp_path, payloads=[
+        {"kind": "submit_plan", "plan": [_STEP_A, _STEP_B]},
+        {"kind": "final_message", "message": "done"},
+    ])
+    result = host.run_root(initial_instruction="go")
+    assert result.status == "completed"
+
+    parent_run_id = next(
+        run_id for run_id, reg in host._run_registry.items()
+        if reg.agent_id == "planner"
+    )
+    plan_events = _named_plan_events(recorder, parent_run_id)
+    assert len(plan_events) == 1
+    ev = plan_events[0]
+    assert ev["is_initial"] is True
+    assert ev["plan_revision"] == 1
+    assert ev["step_count"] == 2
+    assert set(ev["added_step_ids"]) == {"step_a", "step_b"}
+    assert ev["dropped_step_ids"] == []
+    assert len(ev["plan"]) == 2
+    step_ids = {s["id"] for s in ev["plan"]}
+    assert step_ids == {"step_a", "step_b"}
+
+
+def test_plan_updated_event_emitted_on_replan(tmp_path: Path) -> None:
+    host, recorder = _make_host(tmp_path, payloads=[
+        # Initial plan: step_a, step_b
+        {"kind": "submit_plan", "plan": [_STEP_A, _STEP_B]},
+        # After step_a executes and step_b executes, reflect emits a replan dropping step_b, adding step_c
+        {"kind": "submit_plan", "plan": [_STEP_A, _STEP_C]},
+        {"kind": "final_message", "message": "replanned done"},
+    ])
+    result = host.run_root(initial_instruction="go")
+    assert result.status == "completed"
+
+    parent_run_id = next(
+        run_id for run_id, reg in host._run_registry.items()
+        if reg.agent_id == "planner"
+    )
+    plan_events = _named_plan_events(recorder, parent_run_id)
+    assert len(plan_events) == 2
+
+    initial = plan_events[0]
+    assert initial["is_initial"] is True
+    assert initial["plan_revision"] == 1
+
+    replan = plan_events[1]
+    assert replan["is_initial"] is False
+    assert replan["plan_revision"] == 2
+    assert "step_b" in replan["dropped_step_ids"]
+    assert "step_c" in replan["added_step_ids"]
+    assert len(replan["plan"]) == 2

--- a/tests/test_agent_response_field.py
+++ b/tests/test_agent_response_field.py
@@ -1,0 +1,152 @@
+"""Tests for the message/response split introduced in FEAT #76 Phase 1."""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import pytest
+
+from agent_framework.agents.agent_decision import AgentDecision
+from agent_framework.agents.agent_result import AgentResult
+from agent_framework.agents.result_envelope import render_subagent_envelope
+from agent_framework.model import ModelResponse
+from agent_framework_evaluator.evaluation import select_agent_result_field
+
+
+# ---------------------------------------------------------------------------
+# AgentDecision.from_model_response — response field parsing
+# ---------------------------------------------------------------------------
+
+def _resp(payload: dict) -> ModelResponse:
+    return ModelResponse(payload=payload, raw_text=str(payload))
+
+
+def test_parser_reads_response_field():
+    decision = AgentDecision.from_model_response(
+        _resp({"kind": "final_message", "message": "done", "response": {"status": "ok", "count": 3}}),
+    )
+    assert decision.response == {"status": "ok", "count": 3}
+    assert decision.message == "done"
+
+
+def test_parser_response_takes_precedence_over_parameters():
+    decision = AgentDecision.from_model_response(
+        _resp({
+            "kind": "final_message",
+            "message": "done",
+            "response": {"a": 1},
+            "parameters": {"b": 2},
+        }),
+    )
+    assert decision.response == {"a": 1}
+    assert decision.parameters == {"b": 2}
+
+
+def test_parser_no_response_no_deprecation_warning_for_non_final_message(caplog):
+    with caplog.at_level(logging.WARNING):
+        decision = AgentDecision.from_model_response(
+            _resp({"kind": "call_tool", "tool_name": "echo", "parameters": {"msg": "hi"}}),
+        )
+    assert decision.response is None
+    assert not any("Deprecated" in r.message for r in caplog.records)
+
+
+def test_parser_parameters_on_final_message_emits_deprecation(caplog):
+    with caplog.at_level(logging.WARNING):
+        decision = AgentDecision.from_model_response(
+            _resp({"kind": "final_message", "message": "done", "parameters": {"x": 42}}),
+        )
+    # Phase 1: response is NOT mirrored from parameters — only a deprecation warning fires.
+    assert decision.response is None
+    assert decision.parameters == {"x": 42}
+    assert any("Deprecated" in r.message for r in caplog.records)
+
+
+def test_parser_response_none_when_not_set():
+    decision = AgentDecision.from_model_response(
+        _resp({"kind": "final_message", "message": "plain text result"}),
+    )
+    assert decision.response is None
+
+
+# ---------------------------------------------------------------------------
+# AgentResult — response field present
+# ---------------------------------------------------------------------------
+
+def test_agent_result_has_response_field():
+    r = AgentResult(status="completed", message="hi", response={"key": "val"})
+    assert r.response == {"key": "val"}
+
+
+def test_agent_result_response_defaults_to_none():
+    r = AgentResult(status="completed", message="hi")
+    assert r.response is None
+
+
+# ---------------------------------------------------------------------------
+# render_subagent_envelope
+# ---------------------------------------------------------------------------
+
+def test_envelope_returns_message_when_response_none():
+    assert render_subagent_envelope(message="hello", response=None) == "hello"
+
+
+def test_envelope_wraps_response_in_xml():
+    out = render_subagent_envelope(message="summary", response={"a": 1})
+    assert '<subagent_result message="summary">' in out
+    assert '"a": 1' in out
+    assert "</subagent_result>" in out
+
+
+def test_envelope_escapes_quotes_in_message():
+    out = render_subagent_envelope(message='say "hi"', response={"x": 0})
+    assert 'message="say &quot;hi&quot;"' in out
+
+
+def test_envelope_escapes_newlines_in_message():
+    out = render_subagent_envelope(message="line1\nline2", response={"x": 0})
+    assert "&#10;" in out
+
+
+# ---------------------------------------------------------------------------
+# select_agent_result_field — response.* traversal
+# ---------------------------------------------------------------------------
+
+def _result(message: str = "", response: dict | None = None, parameters: dict | None = None) -> dict:
+    r: dict[str, Any] = {"status": "completed", "message": message}
+    if response is not None:
+        r["response"] = response
+    if parameters is not None:
+        r["parameters"] = parameters
+    return r
+
+
+def test_select_message_field():
+    assert select_agent_result_field(_result(message="hello"), "message") == "hello"
+
+
+def test_select_response_dot_path():
+    r = _result(response={"nested": {"value": 42}})
+    assert select_agent_result_field(r, "response.nested.value") == "42"
+
+
+def test_select_response_takes_precedence_over_parameters():
+    r = _result(response={"x": "from_response"}, parameters={"x": "from_params"})
+    assert select_agent_result_field(r, "response.x") == "from_response"
+
+
+def test_select_parameters_fallback():
+    r = _result(parameters={"y": "val"})
+    assert select_agent_result_field(r, "parameters.y") == "val"
+
+
+def test_select_missing_field_returns_none():
+    r = _result(message="hi")
+    assert select_agent_result_field(r, "response.missing") is None
+
+
+def test_select_dot_returns_full_payload():
+    r = _result(message="hi", response={"a": 1})
+    full = select_agent_result_field(r, ".")
+    assert full is not None
+    assert "message" in full

--- a/tests/test_agent_response_field.py
+++ b/tests/test_agent_response_field.py
@@ -51,15 +51,11 @@ def test_parser_no_response_no_deprecation_warning_for_non_final_message(caplog)
     assert not any("Deprecated" in r.message for r in caplog.records)
 
 
-def test_parser_parameters_on_final_message_emits_deprecation(caplog):
-    with caplog.at_level(logging.WARNING):
-        decision = AgentDecision.from_model_response(
+def test_parser_parameters_on_final_message_raises():
+    with pytest.raises(ValueError, match="final_message with structured output must use 'response'"):
+        AgentDecision.from_model_response(
             _resp({"kind": "final_message", "message": "done", "parameters": {"x": 42}}),
         )
-    # Phase 1: response is NOT mirrored from parameters — only a deprecation warning fires.
-    assert decision.response is None
-    assert decision.parameters == {"x": 42}
-    assert any("Deprecated" in r.message for r in caplog.records)
 
 
 def test_parser_response_none_when_not_set():

--- a/tests/test_evaluator_cli.py
+++ b/tests/test_evaluator_cli.py
@@ -992,6 +992,7 @@ def test_web_command_sets_agent_model_override_defaults(monkeypatch: pytest.Monk
             "web",
             "--env",
             ".env",
+            "--no-open-browser",
             "--agent-model-override",
             "gpt-4o",
             "--agent-model-override-scope",

--- a/tests/test_framework_runtime.py
+++ b/tests/test_framework_runtime.py
@@ -1737,8 +1737,8 @@ def test_no_skill_tool_registered_on_invocation(tmp_path: Path) -> None:
 # AgentResult.parameters propagation
 # ---------------------------------------------------------------------------
 
-def test_agent_result_carries_parameters_from_final_message_decision(tmp_path: Path) -> None:
-    """handle_final_message must propagate decision.parameters into AgentResult.parameters."""
+def test_agent_result_carries_response_from_final_message_decision(tmp_path: Path) -> None:
+    """handle_final_message propagates decision.response into AgentResult.response."""
     env_path = tmp_path / ".env"
     write_env(env_path)
     agent = Agent(
@@ -1757,17 +1757,17 @@ def test_agent_result_carries_parameters_from_final_message_decision(tmp_path: P
             {
                 "kind": "final_message",
                 "message": "parsed 2 intents",
-                "parameters": {"intents": ["move", "attack"], "confidence": 0.9},
+                "response": {"intents": ["move", "attack"], "confidence": 0.9},
             }
         ]),
     )
     result = agent.run(host=host, parameters={}, caller_id="host")
     assert result.message == "parsed 2 intents"
-    assert result.parameters == {"intents": ["move", "attack"], "confidence": 0.9}
+    assert result.response == {"intents": ["move", "attack"], "confidence": 0.9}
 
 
-def test_agent_result_parameters_none_when_decision_has_no_parameters(tmp_path: Path) -> None:
-    """AgentResult.parameters stays None when decision carries no parameters."""
+def test_agent_result_response_none_when_no_response_in_decision(tmp_path: Path) -> None:
+    """AgentResult.response stays None when final_message carries no response."""
     env_path = tmp_path / ".env"
     write_env(env_path)
     agent = Agent(
@@ -1785,82 +1785,29 @@ def test_agent_result_parameters_none_when_decision_has_no_parameters(tmp_path: 
         model_driver=FakeModelDriver([{"kind": "final_message", "message": "done"}]),
     )
     result = agent.run(host=host, parameters={}, caller_id="host")
-    assert result.parameters is None
+    assert result.response is None
 
 
-def test_subagent_result_payload_merges_message_and_parameters() -> None:
-    """_subagent_result_payload produces a JSON envelope when parameters are present."""
-    from agent_framework.agents.agent import _subagent_result_payload
+def test_render_result_envelope_with_response() -> None:
+    """render_subagent_envelope produces an XML envelope when response is set."""
+    from agent_framework.agents.result_envelope import render_subagent_envelope
 
-    payload = _subagent_result_payload("I captured 3 intents", {"intents": ["a", "b", "c"]})
-    parsed = json.loads(payload)
-    assert parsed["message"] == "I captured 3 intents"
-    assert parsed["intents"] == ["a", "b", "c"]
-
-
-def test_subagent_result_payload_plain_text_when_no_parameters() -> None:
-    """_subagent_result_payload returns plain message when no parameters."""
-    from agent_framework.agents.agent import _subagent_result_payload
-
-    assert _subagent_result_payload("simple reply", None) == "simple reply"
-    assert _subagent_result_payload("simple reply", {}) == "simple reply"
+    out = render_subagent_envelope(message="I captured 3 intents", response={"intents": ["a", "b", "c"]})
+    assert '<subagent_result message="I captured 3 intents">' in out
+    import json as _json
+    body = out.split(">", 1)[1].rsplit("</", 1)[0].strip()
+    assert _json.loads(body) == {"intents": ["a", "b", "c"]}
 
 
-def test_subagent_result_payload_append_mode() -> None:
-    """append mode: message kept verbatim, parameters appended as fenced JSON block."""
-    from agent_framework.agents.agent import _subagent_result_payload
+def test_render_result_envelope_plain_text_when_no_response() -> None:
+    """render_subagent_envelope returns plain message when response is None."""
+    from agent_framework.agents.result_envelope import render_subagent_envelope
 
-    result = _subagent_result_payload("captured 3 intents", {"intents": ["a"]}, "append")
-    assert result.startswith("captured 3 intents\n```\n")
-    assert result.endswith("\n```")
-    fenced = result.split("```\n", 1)[1].rstrip("\n`")
-    assert json.loads(fenced) == {"intents": ["a"]}
+    assert render_subagent_envelope(message="simple reply", response=None) == "simple reply"
 
 
-def test_subagent_result_payload_ignore_mode() -> None:
-    """ignore mode: message returned unchanged, parameters discarded."""
-    from agent_framework.agents.agent import _subagent_result_payload
-
-    assert _subagent_result_payload("summary only", {"secret": 42}, "ignore") == "summary only"
-
-
-def test_agent_loads_parameters_injection_from_frontmatter(tmp_path: Path) -> None:
-    """parameters_injection frontmatter field is parsed and stored on Agent."""
-    agent_path = tmp_path / "parser.md"
-    agent_path.write_text(
-        "---\nid: parser\nrole: parser\ndescription: p\nparameters_injection: append\n---\nsys\n---\ngo\n",
-        encoding="utf-8",
-    )
-    agent = Agent.from_markdown(agent_path, default_provider="openai", default_model=("gpt-4o-mini",))
-    assert agent.parameters_injection == "append"
-
-
-def test_agent_parameters_injection_defaults_to_override(tmp_path: Path) -> None:
-    """parameters_injection defaults to 'override' when absent from frontmatter."""
-    agent_path = tmp_path / "simple.md"
-    agent_path.write_text(
-        "---\nid: simple\nrole: r\ndescription: d\n---\nsys\n---\ngo\n",
-        encoding="utf-8",
-    )
-    agent = Agent.from_markdown(agent_path, default_provider="openai", default_model=("gpt-4o-mini",))
-    assert agent.parameters_injection == "override"
-
-
-def test_agent_invalid_parameters_injection_raises(tmp_path: Path) -> None:
-    """An unrecognised parameters_injection value raises AgentMarkdownError."""
-    from agent_framework.agents.helpers import AgentMarkdownError
-
-    agent_path = tmp_path / "bad.md"
-    agent_path.write_text(
-        "---\nid: bad\nrole: r\ndescription: d\nparameters_injection: merge\n---\nsys\n---\ngo\n",
-        encoding="utf-8",
-    )
-    with pytest.raises(AgentMarkdownError, match="parameters_injection"):
-        Agent.from_markdown(agent_path, default_provider="openai", default_model=("gpt-4o-mini",))
-
-
-def test_call_subagent_append_mode_keeps_message_and_appends_params(tmp_path: Path) -> None:
-    """When child uses append mode, parent sees prose summary + fenced JSON block."""
+def test_call_subagent_response_envelope_injected_into_parent(tmp_path: Path) -> None:
+    """When child returns response, parent sees the typed XML envelope."""
     host, driver = _make_subagent_host(
         tmp_path,
         parent_id="orchestrator",
@@ -1870,15 +1817,11 @@ def test_call_subagent_append_mode_keeps_message_and_appends_params(tmp_path: Pa
             {
                 "kind": "final_message",
                 "message": "captured 2 intents",
-                "parameters": {"intents": ["move", "attack"]},
+                "response": {"intents": ["move", "attack"]},
             },
             {"kind": "final_message", "message": "done"},
         ],
     )
-    # Override the parser agent's parameters_injection after loading
-    parser = host.agent_registry.get("parser")
-    object.__setattr__(parser, "parameters_injection", "append")
-
     host.run_root(initial_instruction="go")
 
     orchestrator_contexts = [c for c in driver.contexts if len(list(c.messages)) > 2]
@@ -1889,30 +1832,23 @@ def test_call_subagent_append_mode_keeps_message_and_appends_params(tmp_path: Pa
     )
     assert last_user_msg is not None
     content = last_user_msg.split("Subagent result parser: ", 1)[1]
-    assert content.startswith("captured 2 intents\n```\n")
-    params = json.loads(content.split("```\n", 1)[1].rstrip("\n`"))
-    assert params == {"intents": ["move", "attack"]}
+    assert '<subagent_result message="captured 2 intents">' in content
+    body = content.split(">", 1)[1].rsplit("</", 1)[0].strip()
+    assert json.loads(body) == {"intents": ["move", "attack"]}
 
 
-def test_call_subagent_ignore_mode_drops_parameters(tmp_path: Path) -> None:
-    """When child uses ignore mode, parent sees only the prose message."""
+def test_call_subagent_plain_message_when_no_response(tmp_path: Path) -> None:
+    """When child returns no response, parent sees the plain prose message."""
     host, driver = _make_subagent_host(
         tmp_path,
         parent_id="orchestrator",
         child_id="parser",
         decisions=[
             {"kind": "call_subagent", "subagent_id": "parser", "parameters": {}},
-            {
-                "kind": "final_message",
-                "message": "summary only",
-                "parameters": {"hidden": True},
-            },
+            {"kind": "final_message", "message": "summary only"},
             {"kind": "final_message", "message": "done"},
         ],
     )
-    parser = host.agent_registry.get("parser")
-    object.__setattr__(parser, "parameters_injection", "ignore")
-
     host.run_root(initial_instruction="go")
 
     orchestrator_contexts = [c for c in driver.contexts if len(list(c.messages)) > 2]
@@ -2112,28 +2048,24 @@ def _make_subagent_host(tmp_path: Path, parent_id: str, child_id: str, decisions
     return host, driver
 
 
-def test_call_subagent_injects_json_envelope_when_parameters_present(tmp_path: Path) -> None:
-    """Parent conversation must contain the JSON envelope when the child returns parameters."""
+def test_call_subagent_injects_xml_envelope_when_response_present(tmp_path: Path) -> None:
+    """Parent conversation must contain the typed XML envelope when the child returns response."""
     host, driver = _make_subagent_host(
         tmp_path,
         parent_id="orchestrator",
         child_id="parser",
         decisions=[
-            # orchestrator turn 1: call subagent
             {"kind": "call_subagent", "subagent_id": "parser", "parameters": {}},
-            # parser: final_message WITH parameters
             {
                 "kind": "final_message",
                 "message": "parsed 2 intents",
-                "parameters": {"intents": ["move", "attack"]},
+                "response": {"intents": ["move", "attack"]},
             },
-            # orchestrator turn 2 (after subagent result injected): finish
             {"kind": "final_message", "message": "orchestration done"},
         ],
     )
     host.run_root(initial_instruction="go")
 
-    # The second orchestrator decide() call contains the injected subagent result.
     orchestrator_contexts = [c for c in driver.contexts if len(list(c.messages)) > 2]
     assert orchestrator_contexts, "expected at least one orchestrator context with subagent result"
     last_user_msg = next(
@@ -2142,13 +2074,14 @@ def test_call_subagent_injects_json_envelope_when_parameters_present(tmp_path: P
         None,
     )
     assert last_user_msg is not None, "subagent result message not found in orchestrator context"
-    envelope = json.loads(last_user_msg.split("Subagent result parser: ", 1)[1])
-    assert envelope["message"] == "parsed 2 intents"
-    assert envelope["intents"] == ["move", "attack"]
+    content = last_user_msg.split("Subagent result parser: ", 1)[1]
+    assert '<subagent_result message="parsed 2 intents">' in content
+    body = content.split(">", 1)[1].rsplit("</", 1)[0].strip()
+    assert json.loads(body) == {"intents": ["move", "attack"]}
 
 
-def test_call_subagent_injects_plain_text_when_no_parameters(tmp_path: Path) -> None:
-    """Parent conversation must get plain text when child returns no parameters."""
+def test_call_subagent_injects_plain_text_when_no_response(tmp_path: Path) -> None:
+    """Parent conversation must get plain text when child returns no response."""
     host, driver = _make_subagent_host(
         tmp_path,
         parent_id="orchestrator",
@@ -2170,5 +2103,5 @@ def test_call_subagent_injects_plain_text_when_no_parameters(tmp_path: Path) -> 
     )
     assert last_user_msg is not None
     content_after_prefix = last_user_msg.split("Subagent result helper: ", 1)[1]
-    # No parameters: must be plain text, not a JSON envelope.
+    # No response: must be plain text, not an envelope.
     assert content_after_prefix == "helper done"


### PR DESCRIPTION
## Summary

- **Root cause addressed**: `message` was overloaded as both human-readable prose and a JSON-serialized structured output container. `_subagent_result_payload` triple-encoded data; `system.json_object.md` instructed double-write; `AgentResult.parameters` and `AgentDecision.parameters` had different semantics under the same name.
- **Phase 1** (additive): introduces `response: dict | None` on `AgentResult` and `AgentDecision`. `render_subagent_envelope` replaces `_subagent_result_payload`. Evaluator `select_agent_result_field` traverses `response.*` first, then `parameters.*`. Prompts updated to separate prose (`message`) from structured output (`response`).
- **Phase 2** (breaking): removes `AgentResult.parameters`, `AgentResult.parameters_injection`, and all `_subagent_result_payload` machinery. `final_message` decisions that carry structured output must use `response`; using `parameters` raises `ValueError`.
- **Commit 4**: extracts `BaseTurnDriver` in `agents/turn_driver.py` with `_make_result`, `_emit_safety_cap_callback`, and `_try_decide` (decide + per-run `ValueError` retry counter on `AgentRun`). `StandardTurnDriver` and `PlanningTurnDriver` both inherit from it. Removes the `_plan_phase_failures` instance dict and moves `consecutive_validation_failures` from `PlanState` onto `AgentRun`.
- **Evaluator UI**: long-message popup now shows **Message** (markdown with line-break support) and **Response** (prettified JSON) tabs when a trace payload has both `message` and `response` fields.

## Test plan

- [x] `pytest` passes (non-dial suite: 663 passed, 0 new failures)
- [x] Phase 1: existing agents using `parameters` continue working with deprecation warning
- [x] Phase 2: `final_message` with `parameters` raises `ValueError`
- [x] `BaseTurnDriver._try_decide` retry counter lives on `AgentRun`, not on driver instance
- [x] Planning safety-cap tests pass with moved counter
- [ ] Manual: run evaluator UI, click a truncated `message` in an `agent_finished` payload, verify Message/Response tabs appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)