### PR TITLE
fix: use aliased openBatchCaseEvaluationModalUi in getEvaluationUiDeps

### DIFF
--- a/src/agent_framework_evaluator/web/app.js
+++ b/src/agent_framework_evaluator/web/app.js
@@ -169,7 +169,7 @@ function getEvaluationUiDeps() {
     fillEvaluationDetailDom,
     hideCaseEvalSubpanels,
     normalizeUsageTotals,
-    openBatchCaseEvaluationModal,
+    openBatchCaseEvaluationModal: openBatchCaseEvaluationModalUi,
     renderEvalScoreBar,
     setLastEvaluationPayload: (payload) => {
       lastEvaluationPayload = payload;


### PR DESCRIPTION
The EvaluationUi destructuring aliased openBatchCaseEvaluationModal to openBatchCaseEvaluationModalUi, but getEvaluationUiDeps referenced the unaliased name, causing ReferenceError on every Send click.